### PR TITLE
Wire PhysicsGuard into audit + equation_bridge (3 bridges, 10 tests)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,18 @@ jobs:
       - name: Run PhysicsGuard tests
         working-directory: physics_guard
         run: pytest tests/ -v
+
+  bridges:
+    name: PhysicsGuard <-> Math-Econ bridge tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install bridge-test deps
+        # numpy is required for AI/equation_bridge.py; without it the
+        # organizational-physics bridge tests skip silently.
+        run: pip install numpy
+      - name: Run bridge tests
+        run: python tests/test_bridges.py

--- a/AI/equation_bridge.py
+++ b/AI/equation_bridge.py
@@ -9,7 +9,7 @@ of structural indices from thermodynamic inputs.
 
 import sys
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -33,6 +33,18 @@ try:
     _HAS_TEMPORAL = True
 except Exception:
     _HAS_TEMPORAL = False
+
+# Optional PhysicsGuard organizational constraint check. physics_guard/
+# is vendored with flat internal imports; we add its directory to sys.path
+# rather than importing it as a package. See physics_guard/PROVENANCE.md.
+_pg_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "physics_guard")
+if os.path.isdir(_pg_dir) and _pg_dir not in sys.path:
+    sys.path.insert(0, _pg_dir)
+try:
+    from domains.organizational import OrgClaim, check_organization  # type: ignore
+    _HAS_PHYSICS_GUARD = True
+except Exception:
+    _HAS_PHYSICS_GUARD = False
 
 
 # ============================================================================
@@ -107,6 +119,71 @@ class SystemMeasurement:
             for k in components
         )
         return self.osdi
+
+    def check_organizational_physics(
+        self,
+        node_count: int,
+        single_point_deps: int = 0,
+        justification: str = "",
+        structure_type: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Run PhysicsGuard's organizational constraint check on this system.
+
+        Derives `OrgClaim` fields from the measured equations where possible:
+            - structure_type   <- inferred from HHI unless explicitly provided
+                                  (>2500 hierarchical, <1500 distributed, else mixed).
+            - enforcement_ratio <- ER (extraction rate) if measured, else 0.30.
+            - adaptive_slack   <- 1.0 - ER as a best-available proxy.
+
+        Returns None if PhysicsGuard is not importable (see
+        physics_guard/PROVENANCE.md). Otherwise returns a dict with the
+        OrgConstraintResult fields that are stable across calls:
+        verdict, flags, resilience_score, enforcement_waste, cascade_risk,
+        plus the underlying per-law audit trail.
+        """
+        if not _HAS_PHYSICS_GUARD:
+            return None
+
+        if structure_type is None:
+            hhi_result = self.results.get("HHI")
+            if hhi_result is None:
+                structure_type = "mixed"
+            elif hhi_result.value > 2500:
+                structure_type = "hierarchical"
+            elif hhi_result.value < 1500:
+                structure_type = "distributed"
+            else:
+                structure_type = "mixed"
+
+        er_result = self.results.get("ER")
+        if er_result is not None:
+            enforcement_ratio = max(0.0, min(1.0, er_result.value))
+            adaptive_slack = max(0.0, 1.0 - enforcement_ratio)
+        else:
+            enforcement_ratio = 0.30
+            adaptive_slack = 0.30
+
+        claim = OrgClaim(
+            raw=f"derived from SystemMeasurement ({len(self.results)} eqs measured)",
+            structure_type=structure_type,
+            enforcement_ratio=enforcement_ratio,
+            adaptive_slack=adaptive_slack,
+            node_count=node_count,
+            single_point_deps=single_point_deps,
+            justification=justification,
+        )
+        result = check_organization(claim)
+        return {
+            "verdict": result.verdict,
+            "flags": list(result.flags),
+            "resilience_score": result.resilience_score,
+            "enforcement_waste": result.enforcement_waste,
+            "cascade_risk": result.cascade_risk,
+            "audit": list(result.audit),
+            "derived_structure_type": structure_type,
+            "derived_enforcement_ratio": enforcement_ratio,
+            "derived_adaptive_slack": adaptive_slack,
+        }
 
     def summary_table(self) -> str:
         """Formatted summary of all measurements."""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Mathematic-economics/
 │   ├── tests/                          # 76 pytest tests
 │   ├── main.py, ai_interface.py, monoculture_detector.py
 │   └── PROVENANCE.md                   # Snapshot metadata and integration points
+├── tests/                              # Integration tests across the three PhysicsGuard bridges
+│   └── test_bridges.py                 # 10 unittest tests (6 always, 4 require numpy)
 ├── schemas/                            # Versioned data contracts for inter-module shapes
 │   ├── __init__.py
 │   └── field_system_contract.py        # Stable shape for field_system state / report
@@ -152,6 +154,16 @@ Markdown specifications for the five compounding labor-measurement failure modes
 ### physics_guard/
 Vendored snapshot of [JinnZ2/PhysicsGuard](https://github.com/JinnZ2/PhysicsGuard) (CC0). Physics-grounded claim verification: `core/` pipeline parses a natural-language premise, maps it to a conservation equation, checks imbalance, and emits a scored `Verdict` with an audit trail. `domains/organizational.py` and `domains/information.py` apply the pipeline to structural-resilience and information-theoretic (Landauer, Shannon) constraints. `monoculture_detector.py` analyzes lexical/causal diversity — directly relevant to the HHI concentration metric in `README.md`. 76 pytest tests at snapshot. See `physics_guard/PROVENANCE.md` for snapshot version and integration points.
 
+### PhysicsGuard bridges
+Three wiring points connect PhysicsGuard into the existing Math-Econ modules. All three are defensive: they set `_HAS_PHYSICS_GUARD = False` and fall back to the pre-bridge behavior if `physics_guard/` is not importable.
+
+- **`audit/efficiency_report_audit.py`** — `audit_efficiency_report()` now routes each report's headline claim through `physics_guard.main.check()` and attaches the verdict to the return dict under `physics_verdict`. A `CORRUPTED` verdict means the headline is physically impossible regardless of the Six Sigma audit outcome.
+- **`audit/ai_delusion_econ_checker.py`** — `analyze_dataset_with_physics()` keeps the existing regex analysis and adds a per-entry PhysicsGuard verdict list. The original `analyze_dataset()` is untouched so downstream callers are unaffected.
+- **`AI/equation_bridge.py`** — `SystemMeasurement.check_organizational_physics(node_count, ...)` constructs a `domains.organizational.OrgClaim` from the measured equations (HHI → structure type, ER → enforcement ratio, `1 - ER` → adaptive slack) and returns the `check_organization()` verdict plus audit trail.
+
+### tests/test_bridges.py
+10 unittest tests verifying the three bridges end-to-end: import wiring, output shape, graceful fallback when PhysicsGuard is absent, and correct derivation of `OrgClaim` fields from measured equations. Run with `python tests/test_bridges.py`. The 4 tests covering `equation_bridge` skip automatically in environments without numpy.
+
 ### data/fetch_and_compute.py, data/sensitivity_analysis.py
 External data ingestion and Monte Carlo sensitivity analysis across weight and threshold ranges for the composite indices defined in `README.md`.
 
@@ -192,9 +204,12 @@ python calibration/self_audit.py         # repo audits itself
 
 # PhysicsGuard test suite (requires pytest)
 cd physics_guard && pytest tests/        # 76 tests
+
+# Integration tests for the three PhysicsGuard bridges
+python tests/test_bridges.py             # 10 tests (4 skip without numpy)
 ```
 
-CI runs both suites on push / PR via `.github/workflows/tests.yml`.
+CI runs all three suites on push / PR via `.github/workflows/tests.yml`.
 
 There are no linting or formatting configurations. No `requirements.txt` or `pyproject.toml` exists — install dependencies manually:
 

--- a/audit/ai_delusion_econ_checker.py
+++ b/audit/ai_delusion_econ_checker.py
@@ -3,9 +3,21 @@
 # productivity, economics) in AI datasets and score plausibility against
 # real-world constraints.
 
+import os
 import re
+import sys
 from collections import Counter
-from typing import Dict, List
+from typing import Any, Dict, List
+
+# Optional PhysicsGuard integration. See physics_guard/PROVENANCE.md.
+_PG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "physics_guard")
+if os.path.isdir(_PG_DIR) and _PG_DIR not in sys.path:
+    sys.path.insert(0, _PG_DIR)
+try:
+    from main import check as physics_check  # type: ignore
+    _HAS_PHYSICS_GUARD = True
+except Exception:
+    _HAS_PHYSICS_GUARD = False
 
 # ---------------------------
 # Patterns for conceptual delusions
@@ -88,6 +100,32 @@ def analyze_dataset(dataset: List[str]) -> Dict:
     }
 
 
+def analyze_dataset_with_physics(dataset: List[str]) -> Dict[str, Any]:
+    """Regex-based analysis augmented with PhysicsGuard verdicts.
+
+    Runs the standard `analyze_dataset` pipeline AND passes each entry through
+    PhysicsGuard's `check()` to screen for physical conservation violations
+    (e.g. "efficiency beyond 100%"). Falls back to regex-only if the
+    physics_guard snapshot is not importable.
+
+    Returned dict contains:
+        - delusion_counts: aggregated regex pattern counts
+        - plausibility_flags: per-entry regex plausibility flags
+        - physics_verdicts: per-entry PhysicsGuard verdict dicts (or None)
+        - physics_available: whether PhysicsGuard was usable
+    """
+    base = analyze_dataset(dataset)
+    if _HAS_PHYSICS_GUARD:
+        verdicts = [physics_check(entry) for entry in dataset]
+    else:
+        verdicts = [None] * len(dataset)
+    return {
+        **base,
+        "physics_verdicts": verdicts,
+        "physics_available": _HAS_PHYSICS_GUARD,
+    }
+
+
 if __name__ == "__main__":
     from pprint import pprint
 
@@ -97,4 +135,12 @@ if __name__ == "__main__":
         "Productivity and optimization are the sole drivers of economic success.",
     ]
 
+    print("=== regex-only ===")
     pprint(analyze_dataset(sample_dataset))
+    print("\n=== regex + PhysicsGuard ===")
+    augmented = analyze_dataset_with_physics(sample_dataset)
+    print(f"physics_available: {augmented['physics_available']}")
+    for entry, verdict in zip(sample_dataset, augmented["physics_verdicts"]):
+        if verdict is None:
+            continue
+        print(f"  [{verdict['verdict']:>9s} score={verdict['score']:.2f}]  {entry[:70]}")

--- a/audit/efficiency_report_audit.py
+++ b/audit/efficiency_report_audit.py
@@ -4,11 +4,26 @@
 # representative archetypes through the Six Sigma auditor and field-system
 # rule engine, then comparing against a first-principles baseline.
 
+import os
+import sys
 from datetime import datetime
 from typing import Any, Dict
 
 from field_system import effective_yield, fill_state, report
 from system_audit import SixSigmaAudit
+
+# Optional PhysicsGuard integration. physics_guard/ is a vendored snapshot
+# (see physics_guard/PROVENANCE.md) with flat internal imports, so we add it
+# to sys.path rather than importing it as a package. If unavailable, the
+# audit runs without the physics-verdict step.
+_PG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "physics_guard")
+if os.path.isdir(_PG_DIR) and _PG_DIR not in sys.path:
+    sys.path.insert(0, _PG_DIR)
+try:
+    from main import check as physics_check  # type: ignore
+    _HAS_PHYSICS_GUARD = True
+except Exception:
+    _HAS_PHYSICS_GUARD = False
 
 
 # ---------------------------
@@ -123,14 +138,20 @@ REPORT_ARCHETYPES: Dict[str, Dict[str, Any]] = {
 
 
 def audit_efficiency_report(report_type: str, auditor: SixSigmaAudit) -> Dict[str, Any]:
-    """Run audit on one of the efficiency-report archetypes."""
+    """Run audit on one of the efficiency-report archetypes.
+
+    When PhysicsGuard is available, the report's headline claim is also
+    screened against physical conservation laws. A CORRUPTED physics
+    verdict means the claim is impossible regardless of what the Six Sigma
+    audit concludes downstream.
+    """
     report_data = REPORT_ARCHETYPES.get(report_type, REPORT_ARCHETYPES["precision_ag"])
     scenario = report_data["parameters"]
 
     audit = auditor.audit_claim(scenario, report_data["name"])
     yield_analysis = effective_yield(fill_state(scenario))
 
-    return {
+    result = {
         "report_type": report_data["name"],
         "claims": report_data["claims"],
         "audit": audit,
@@ -141,6 +162,14 @@ def audit_efficiency_report(report_type: str, auditor: SixSigmaAudit) -> Dict[st
         # Ratio of missing wild space relative to a 200-acre reference.
         "ecological_debt": 1.0 - (scenario["ecological_area"] / 200),
     }
+
+    if _HAS_PHYSICS_GUARD:
+        headline = report_data["claims"].get("headline", "")
+        result["physics_verdict"] = physics_check(headline) if headline else None
+    else:
+        result["physics_verdict"] = None
+
+    return result
 
 
 # ---------------------------
@@ -190,6 +219,17 @@ def run_audit_suite():
         print("\nClaims Made:")
         for claim, value in result["claims"].items():
             print(f"  - {claim}: {value}")
+
+        verdict = result.get("physics_verdict")
+        if verdict is not None:
+            print("\nPhysicsGuard Pre-Screen (headline claim):")
+            print(f"  Verdict:    {verdict['verdict']}")
+            print(f"  Score:      {verdict['score']:.3f}")
+            print(f"  Confidence: {verdict['confidence']:.0%}")
+            if verdict.get("reason"):
+                print(f"  Reason:     {verdict['reason']}")
+            for viol in verdict.get("violations", [])[:2]:
+                print(f"  ! {viol['law']}: {viol['description']}")
 
         audit = result["audit"]
         print("\nAudit Results:")

--- a/physics_guard/PROVENANCE.md
+++ b/physics_guard/PROVENANCE.md
@@ -23,19 +23,22 @@ dependency on another repository.
 
 ## Integration points
 
-The natural bridges into the rest of Math-Econ are:
+All three bridges are wired and covered by `tests/test_bridges.py`:
 
-- `audit/efficiency_report_audit.py` — route headline efficiency claims
-  (e.g., "300% gain") through `core.conservation_checker` before running them
-  through `field_system`.
-- `audit/ai_delusion_econ_checker.py` — replace or augment regex detection
-  with `core.premise_parser` + `core.constraint_mapper`.
-- `AI/equation_bridge.py` — `domains/organizational.py`'s 5 structural
-  constraints (resilience, enforcement ratio, adaptive slack, interdependency
-  load) are direct cousins of the OSDI sub-indices (HHI, SD, RI).
+- **`audit/efficiency_report_audit.py`** — routes each report's headline
+  claim through `main.check()` (full parse → constraint → conservation →
+  flag pipeline) before the Six Sigma audit. Verdict is attached to the
+  audit result as `physics_verdict`.
+- **`audit/ai_delusion_econ_checker.py`** — exposes
+  `analyze_dataset_with_physics()` which keeps the regex path and adds a
+  per-entry PhysicsGuard verdict list.
+- **`AI/equation_bridge.py`** —
+  `SystemMeasurement.check_organizational_physics()` builds an `OrgClaim`
+  from the measured equations (HHI → structure type, ER → enforcement
+  ratio, `1 - ER` → adaptive slack) and calls `check_organization()`.
 
-None of those bridges are wired up yet — this snapshot simply makes them
-possible.
+All three use a defensive `_HAS_PHYSICS_GUARD` flag and fall back to
+pre-bridge behavior if this directory is not importable.
 
 ## Running the tests
 

--- a/tests/test_bridges.py
+++ b/tests/test_bridges.py
@@ -1,0 +1,154 @@
+"""Integration tests for the three PhysicsGuard bridges.
+
+Run from the repo root:
+    python tests/test_bridges.py
+
+Uses unittest (no pytest dependency) so it runs identically locally and in
+CI without extra installs. Each test is defensive: if the underlying module
+can't be imported in the environment (e.g. numpy missing for equation_bridge),
+the test skips rather than fails. The goal is to prove the bridge wiring
+works whenever its dependencies are present, not to retest the upstream
+modules themselves.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for p in (
+    REPO_ROOT,
+    os.path.join(REPO_ROOT, "audit"),
+    os.path.join(REPO_ROOT, "AI"),
+    os.path.join(REPO_ROOT, "physics_guard"),
+):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+class BridgeEfficiencyReport(unittest.TestCase):
+    """audit/efficiency_report_audit.py routes headline claims through
+    PhysicsGuard before the Six Sigma audit."""
+
+    def test_physics_guard_detected(self):
+        import efficiency_report_audit as era
+        self.assertTrue(era._HAS_PHYSICS_GUARD,
+                        "physics_guard should be importable in a default checkout")
+
+    def test_audit_includes_physics_verdict(self):
+        import efficiency_report_audit as era
+        from system_audit import SixSigmaAudit
+        result = era.audit_efficiency_report("precision_ag", SixSigmaAudit())
+        self.assertIn("physics_verdict", result)
+        verdict = result["physics_verdict"]
+        self.assertIsNotNone(verdict, "physics_verdict should be populated when PG is present")
+        for key in ("verdict", "score", "flags", "reason", "confidence"):
+            self.assertIn(key, verdict)
+        self.assertIn(verdict["verdict"], {"CLEAN", "SUSPECT", "CORRUPTED"})
+
+    def test_audit_still_returns_when_pg_absent(self):
+        """Monkey-patch _HAS_PHYSICS_GUARD=False and confirm graceful fallback."""
+        import efficiency_report_audit as era
+        from system_audit import SixSigmaAudit
+        original = era._HAS_PHYSICS_GUARD
+        try:
+            era._HAS_PHYSICS_GUARD = False
+            result = era.audit_efficiency_report("precision_ag", SixSigmaAudit())
+            self.assertIsNone(result["physics_verdict"])
+            self.assertIn("audit", result)  # rest of audit still present
+        finally:
+            era._HAS_PHYSICS_GUARD = original
+
+
+class BridgeDelusionChecker(unittest.TestCase):
+    """audit/ai_delusion_econ_checker.py keeps the regex path and adds
+    a PhysicsGuard verdict per entry via analyze_dataset_with_physics."""
+
+    SAMPLE = [
+        "The company maximized efficiency beyond 100%.",
+        "Top-down management ensures market price is the true value.",
+        "Productivity and optimization drive economic success.",
+    ]
+
+    def test_physics_guard_detected(self):
+        import ai_delusion_econ_checker as adec
+        self.assertTrue(adec._HAS_PHYSICS_GUARD)
+
+    def test_augmented_output_shape(self):
+        import ai_delusion_econ_checker as adec
+        augmented = adec.analyze_dataset_with_physics(self.SAMPLE)
+        self.assertTrue(augmented["physics_available"])
+        self.assertIn("delusion_counts", augmented)
+        self.assertIn("plausibility_flags", augmented)
+        self.assertEqual(len(augmented["physics_verdicts"]), len(self.SAMPLE))
+        for v in augmented["physics_verdicts"]:
+            self.assertIn(v["verdict"], {"CLEAN", "SUSPECT", "CORRUPTED"})
+
+    def test_regex_path_unchanged(self):
+        """The original analyze_dataset output must be preserved intact."""
+        import ai_delusion_econ_checker as adec
+        augmented = adec.analyze_dataset_with_physics(self.SAMPLE)
+        original = adec.analyze_dataset(self.SAMPLE)
+        self.assertEqual(augmented["delusion_counts"], original["delusion_counts"])
+        self.assertEqual(augmented["plausibility_flags"], original["plausibility_flags"])
+
+
+class BridgeOrganizationalPhysics(unittest.TestCase):
+    """AI/equation_bridge.py: SystemMeasurement.check_organizational_physics
+    maps measured equations into a PhysicsGuard OrgClaim and runs
+    check_organization."""
+
+    def setUp(self):
+        try:
+            import equation_bridge  # noqa: F401
+        except ModuleNotFoundError as e:
+            self.skipTest(f"equation_bridge import requires numpy: {e}")
+        except Exception as e:
+            self.skipTest(f"equation_bridge not importable in this env: {e}")
+
+    def test_returns_none_when_pg_absent(self):
+        import equation_bridge as eb
+        sm = eb.SystemMeasurement()
+        original = eb._HAS_PHYSICS_GUARD
+        try:
+            eb._HAS_PHYSICS_GUARD = False
+            self.assertIsNone(sm.check_organizational_physics(node_count=5))
+        finally:
+            eb._HAS_PHYSICS_GUARD = original
+
+    def test_hhi_derives_hierarchical_structure(self):
+        import equation_bridge as eb
+        sm = eb.SystemMeasurement()
+        # HHI uses percentage-points squared (standard convention), so
+        # thresholds are 1500 / 2500. 80/10/10 market shares -> HHI = 6600.
+        sm.add(eb.compute_hhi([80.0, 10.0, 10.0]))
+        result = sm.check_organizational_physics(
+            node_count=10, single_point_deps=8, justification="efficiency"
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["derived_structure_type"], "hierarchical")
+        self.assertIn(result["verdict"], {"CLEAN", "SUSPECT", "CORRUPTED"})
+
+    def test_er_maps_to_enforcement_ratio(self):
+        import equation_bridge as eb
+        sm = eb.SystemMeasurement()
+        sm.add(eb.compute_er(revenue=100.0, labor_costs=20.0))  # ER = 0.80
+        result = sm.check_organizational_physics(node_count=5, single_point_deps=2)
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["derived_enforcement_ratio"], 0.80, places=2)
+        self.assertAlmostEqual(result["derived_adaptive_slack"], 0.20, places=2)
+        self.assertIn("enforcement_energy_cost", result["flags"])
+
+    def test_low_hhi_derives_distributed(self):
+        import equation_bridge as eb
+        sm = eb.SystemMeasurement()
+        # 10 equal competitors -> HHI = 10 * 10^2 = 1000, below 1500.
+        sm.add(eb.compute_hhi([10.0] * 10))
+        result = sm.check_organizational_physics(node_count=10)
+        self.assertEqual(result["derived_structure_type"], "distributed")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Each bridge uses a defensive _HAS_PHYSICS_GUARD flag: if the physics_guard/ snapshot is not importable, the bridge falls back to pre-bridge behavior instead of erroring. This keeps the core repo usable even if someone removes the vendored snapshot or checks out an older commit.

Bridge 1 -- audit/efficiency_report_audit.py:
  audit_efficiency_report() now routes each report's headline claim
  through physics_guard.main.check() (full parse -> constraint ->
  conservation -> flag pipeline) before the Six Sigma audit. Verdict
  lands on the return dict as `physics_verdict` and is displayed in
  run_audit_suite() output. A CORRUPTED verdict means the headline is
  physically impossible regardless of what the audit concludes.

Bridge 2 -- audit/ai_delusion_econ_checker.py:
  New analyze_dataset_with_physics() keeps the original regex-based
  analyze_dataset() untouched and adds a per-entry PhysicsGuard verdict
  list. Downstream callers of analyze_dataset() are unaffected.

Bridge 3 -- AI/equation_bridge.py:
  SystemMeasurement.check_organizational_physics(node_count, ...) builds
  a domains.organizational.OrgClaim from the measured equations and runs
  check_organization():
    - HHI -> structure_type (>2500 hierarchical, <1500 distributed, else mixed)
    - ER  -> enforcement_ratio
    - 1-ER -> adaptive_slack (best-available proxy) Node count, single-point deps, and justification are caller-provided since they are not in the 13-equation set.

Tests:
  tests/test_bridges.py -- 10 unittest tests covering all three bridges:
  wiring detection, output shape, graceful fallback when PG is absent,
  and correct OrgClaim derivation. Uses unittest (no pytest dep) so it
  runs identically locally and in CI. The 4 equation_bridge tests skip
  automatically in environments without numpy.

CI:
  New `bridges` job in tests.yml installs numpy and runs the bridge
  tests. Combined with the existing calibration (11) and physics_guard
  (76) suites, CI now gates 97 passing tests total.

CLAUDE.md + physics_guard/PROVENANCE.md: documented the three bridges and marked the integration points as wired (previously flagged as possible-but-not-wired).