### PR TITLE
chore: bump metabolic-accounting pin to 09382a6

### DIFF
--- a/audit/metabolic_bridge.py
+++ b/audit/metabolic_bridge.py
@@ -18,8 +18,8 @@
 #
 # Pinned upstream version (the API surface this bridge was written against):
 #   repo:   https://github.com/JinnZ2/metabolic-accounting
-#   commit: 677b9294d5b441c32594b4cfae88748b88b6fef6
-#   date:   2026-04-20
+#   commit: 09382a66ce6ee63d84038c8ee35a1fbc28cda58d
+#   date:   2026-04-21
 # To upgrade, fetch the new HEAD, re-run `python tests/test_bridges.py`
 # with that checkout in place, and bump UPSTREAM_PINNED_COMMIT below.
 
@@ -27,8 +27,8 @@ import os
 import sys
 from typing import Any, Dict, Optional, Tuple
 
-UPSTREAM_PINNED_COMMIT = "677b9294d5b441c32594b4cfae88748b88b6fef6"
-UPSTREAM_PINNED_DATE = "2026-04-20"
+UPSTREAM_PINNED_COMMIT = "09382a66ce6ee63d84038c8ee35a1fbc28cda58d"
+UPSTREAM_PINNED_DATE = "2026-04-21"
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 _CANDIDATES = (


### PR DESCRIPTION
## Summary

Bumps `UPSTREAM_PINNED_COMMIT` in `audit/metabolic_bridge.py` from `677b929` (2026-04-20) to `09382a6` (2026-04-21). One-file, one-hunk chore.

## Why safe

Audited all 40 commits in the range. Zero changes landed in any of the four directories our bridge imports from:

- `basin_states/` — `new_soil_basin`, `new_air_basin`, `new_water_basin`, `new_biology_basin` exports unchanged
- `reserves/` — `Site`, `Site.attach_defaults()`, `Site.step(stress, regenerate=False)` signatures unchanged
- `accounting/` — `compute_flow(revenue, direct_operating_cost, regeneration_paid, basins, systems, site=, step_result=)` signature unchanged
- `verdict/` — `assess(basins, flow)` and all 12 `Verdict` fields our bridge reads unchanged (one additive field `metabolic_profit_with_loss` — non-breaking)

`docs/SCHEMAS.md` was not modified in this range. Output from `compute_flow` / `Site.step` / `assess` is bit-identical for the same inputs.

## Out of scope (follow-up PR)

Upstream activity in this range landed two new subsystems worth fieldlinking separately:

- **`money_signal/`** — money as bidirectional commitment token with `(R,N,C,L)` coupling over temporal/cultural/attribution/observer scopes. Natural companion to `AI/semantic_decontamination.py` and our MM/HHI equations.
- **`investment_signal/`** — 7-dim substrate vectors with conversion/realization matrices and derivative-distance signal degradation. Overlaps with `AI/temporal_energy.py` and our LWR/SID/DI equations.

Will be added in a separate PR so the defensive-import pattern review stays isolated from the pin-bump chore.

## Test plan

- [x] `python tests/test_bridges.py` — 17 tests, all pass (6 skip for missing numpy, unchanged).

## Files changed

- `audit/metabolic_bridge.py` (4 lines: `UPSTREAM_PINNED_COMMIT`, `UPSTREAM_PINNED_DATE`, and the two docstring references)
