### PR TITLE
feat: defensive bridge to metabolic-accounting /money_signal/

### DIFF
--- a/AI/equation_bridge.py
+++ b/AI/equation_bridge.py
@@ -58,6 +58,12 @@ try:
 except Exception:
     _HAS_METABOLIC_BRIDGE = False
 
+try:
+    import money_signal_bridge as _msb  # type: ignore
+    _HAS_MONEY_SIGNAL_BRIDGE = True
+except Exception:
+    _HAS_MONEY_SIGNAL_BRIDGE = False
+
 
 # ============================================================================
 # EQUATION RESULTS
@@ -227,6 +233,22 @@ class SystemMeasurement:
             regeneration_paid=regeneration_paid,
             stress=stress,
         )
+
+    def check_money_signal(
+        self,
+        ctx: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return money-signal primitives (minsky, magnitude, has_sign_flips)
+        for the given dimensional context.
+
+        `ctx` is a `money_signal.dimensions.DimensionalContext`; when None,
+        the bridge's neutral default context is used. Returns None when
+        the money_signal_bridge module or its upstream package are not
+        available.
+        """
+        if not _HAS_MONEY_SIGNAL_BRIDGE or not _msb._HAS_MONEY_SIGNAL:
+            return None
+        return _msb.money_signal_metrics(ctx)
 
     def summary_table(self) -> str:
         """Formatted summary of all measurements."""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Mathematic-economics/
 │   ├── incentive_structure.py
 │   ├── incentives_audit.py
 │   ├── metabolic_bridge.py             # Defensive bridge to JinnZ2/metabolic-accounting
+│   ├── money_signal_bridge.py          # Defensive bridge to money_signal/ subsystem
 │   └── system_audit.py                 # Six Sigma-style audit on field_system outputs
 ├── calibration/                        # Falsifiable diagnostics + falsification test suite (stdlib only)
 │   ├── schema.py                       # Band / DimensionScore / CalibrationReport
@@ -170,8 +171,17 @@ A fourth bridge wires Math-Econ into [JinnZ2/metabolic-accounting](https://githu
 - **`audit/efficiency_report_audit.py`** — `audit_efficiency_report()` now also attaches `metabolic_verdict` to the result dict, alongside `physics_verdict`. Revenue/operating-cost are scaled from the scenario's energy ratio, so absolute profit numbers are not meaningful — but the band signal and basin trajectory are.
 - **`AI/equation_bridge.py`** — `SystemMeasurement.check_metabolic_health(revenue, regeneration_paid, stress)` derives operating cost from the measured ER (`operating_cost = revenue * (1 - ER)`) and runs the bridge.
 
+### Money-signal bridge
+A fifth bridge fieldlinks Math-Econ into the `money_signal/` subsystem of [JinnZ2/metabolic-accounting](https://github.com/JinnZ2/metabolic-accounting). Same discovery logic as `metabolic_bridge.py` — probes the same conventional locations and sets `_HAS_MONEY_SIGNAL = False` on failure. Deliberately imports only `money_signal.dimensions` and `money_signal.coupling` (leaf modules, zero side effects); skips `money_signal.accounting_bridge` because it mutates `sys.path` at import time and hard-depends on `term_audit/`.
+
+- **`audit/money_signal_bridge.py`** — exposes `default_context()` (neutral `DimensionalContext` baseline) and `money_signal_metrics(ctx=None)` which returns `{"minsky", "magnitude", "has_sign_flips"}` — the three raw primitives that feed upstream's `signal_quality`. Exposing them raw rather than collapsed avoids the `term_audit` dependency and gives callers more information than a single float.
+- **`audit/efficiency_report_audit.py`** — `audit_efficiency_report()` attaches `money_signal_metrics` to the result dict, alongside `physics_verdict` and `metabolic_verdict`.
+- **`AI/equation_bridge.py`** — `SystemMeasurement.check_money_signal(ctx=None)` forwards to the bridge.
+
+`investment_signal/` is deliberately NOT fieldlinked yet. At upstream commit `09382a6` the subsystem lacks an `__init__.py` and its modules use relative imports (`from ..money_signal import ...`) that require a shared parent package not present in the repo structure. Re-evaluate once upstream resolves that.
+
 ### tests/test_bridges.py
-17 unittest tests verifying all four bridges end-to-end: import wiring, output shape, graceful fallback when PhysicsGuard or metabolic-accounting is absent, and correct derivation of `OrgClaim` fields and ER-scaled operating cost from measured equations. Run with `python tests/test_bridges.py`. The 6 tests covering `equation_bridge` skip automatically in environments without numpy.
+22 unittest tests verifying all five bridges end-to-end: import wiring, output shape, graceful fallback when PhysicsGuard / metabolic-accounting / money_signal is absent, and correct delegation through `SystemMeasurement` methods. Run with `python tests/test_bridges.py`. The 8 tests covering `equation_bridge` skip automatically in environments without numpy.
 
 ### data/fetch_and_compute.py, data/sensitivity_analysis.py
 External data ingestion and Monte Carlo sensitivity analysis across weight and threshold ranges for the composite indices defined in `README.md`.

--- a/audit/efficiency_report_audit.py
+++ b/audit/efficiency_report_audit.py
@@ -29,6 +29,7 @@ except Exception:
 # the discovery logic. The import always succeeds; whether it does anything
 # at runtime is gated on metabolic_bridge._HAS_METABOLIC_ACCOUNTING.
 from metabolic_bridge import metabolic_check, stress_from_field_scenario
+from money_signal_bridge import money_signal_metrics
 
 
 # ---------------------------
@@ -186,6 +187,12 @@ def audit_efficiency_report(report_type: str, auditor: SixSigmaAudit) -> Dict[st
         regeneration_paid=0.0,
         stress=stress_from_field_scenario(scenario),
     )
+
+    # Money-signal metrics (minsky / magnitude / sign-flips). Uses the
+    # bridge's neutral default context; scenarios that want to vary the
+    # six dimensions should call money_signal_bridge.money_signal_metrics
+    # directly. None when the upstream package is not importable.
+    result["money_signal_metrics"] = money_signal_metrics()
 
     return result
 

--- a/audit/money_signal_bridge.py
+++ b/audit/money_signal_bridge.py
@@ -1,0 +1,116 @@
+# money_signal_bridge.py
+# Defensive bridge: Math-Econ -> JinnZ2/metabolic-accounting /money_signal/ (CC0).
+#
+# Companion to audit/metabolic_bridge.py. Shares the same discovery logic:
+# probe a few conventional locations for a metabolic-accounting checkout,
+# set _HAS_MONEY_SIGNAL = False if it can't be found. Every helper returns
+# None in the False case so consumers can wire the call in unconditionally.
+#
+# To make the bridge active, place a checkout adjacent to this repo:
+#   <parent>/metabolic-accounting/    (default git clone name)
+# or vendor a snapshot inside this repo:
+#   <repo_root>/metabolic_accounting/
+#
+# What this bridge does and does not import:
+#   - imports:  money_signal.dimensions, money_signal.coupling (leaf modules,
+#               zero sys.path mutation, no term_audit dependency).
+#   - skips:    money_signal.accounting_bridge, which mutates sys.path at
+#               import time and hard-imports term_audit.* (activating it
+#               would silently make our imports depend on term_audit/ being
+#               present, which is outside this bridge's contract).
+#
+# Returned metrics are the three raw primitives that feed signal_quality
+# upstream (minsky_coefficient, coupling_magnitude, has_sign_flips). We do
+# NOT reimplement the signal_quality formula here — downstream can call the
+# upstream `accounting_bridge.signal_quality(ctx)` directly when it has
+# term_audit available, or interpret the three primitives on its own terms.
+#
+# Pinned upstream version:
+#   repo:   https://github.com/JinnZ2/metabolic-accounting
+#   commit: 09382a66ce6ee63d84038c8ee35a1fbc28cda58d
+#   date:   2026-04-21
+# To upgrade, fetch the new HEAD, re-run `python tests/test_bridges.py` with
+# that checkout in place, and bump UPSTREAM_PINNED_COMMIT below.
+
+import os
+import sys
+from typing import Any, Dict, Optional
+
+UPSTREAM_PINNED_COMMIT = "09382a66ce6ee63d84038c8ee35a1fbc28cda58d"
+UPSTREAM_PINNED_DATE = "2026-04-21"
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_CANDIDATES = (
+    os.path.join(_REPO_ROOT, "metabolic_accounting"),
+    os.path.abspath(os.path.join(_REPO_ROOT, "..", "metabolic-accounting")),
+    os.path.abspath(os.path.join(_REPO_ROOT, "..", "metabolic_accounting")),
+)
+for _p in _CANDIDATES:
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)
+        break
+
+try:
+    from money_signal.dimensions import (  # type: ignore
+        AttributedValue,
+        CulturalScope,
+        DimensionalContext,
+        ObserverPosition,
+        StateRegime,
+        Substrate,
+        TemporalScope,
+    )
+    from money_signal.coupling import (  # type: ignore
+        coupling_magnitude,
+        has_sign_flips,
+        minsky_coefficient,
+    )
+    _HAS_MONEY_SIGNAL = True
+except Exception:
+    _HAS_MONEY_SIGNAL = False
+
+
+def default_context() -> Optional[Any]:
+    """Build a neutral `DimensionalContext` for callers that don't need
+    to vary the six dimensions themselves. Represents a modern digital-
+    money institutional economy in a healthy state — the baseline against
+    which `minsky_coefficient` etc. are scaled upstream.
+
+    Returns None when money_signal is not importable.
+    """
+    if not _HAS_MONEY_SIGNAL:
+        return None
+    return DimensionalContext(
+        temporal=TemporalScope.SEASONAL,
+        cultural=CulturalScope.INSTITUTIONAL,
+        attribution=AttributedValue.STATE_ENFORCED,
+        observer=ObserverPosition.TOKEN_HOLDER_DEEP,
+        substrate=Substrate.DIGITAL,
+        state=StateRegime.HEALTHY,
+    )
+
+
+def money_signal_metrics(ctx: Optional[Any] = None) -> Optional[Dict[str, Any]]:
+    """Return the three raw money-signal primitives for a given context.
+
+        {"minsky": float,
+         "magnitude": float,
+         "has_sign_flips": bool}
+
+    When `ctx` is None, uses `default_context()`. Returns None when
+    money_signal is not importable.
+
+    These are the same three primitives that upstream's
+    `accounting_bridge.signal_quality` collapses into a [0, 1] score.
+    Exposing them raw rather than collapsed avoids a dependency on
+    `term_audit/` and gives callers more information than a single float.
+    """
+    if not _HAS_MONEY_SIGNAL:
+        return None
+    if ctx is None:
+        ctx = default_context()
+    return {
+        "minsky": minsky_coefficient(ctx),
+        "magnitude": coupling_magnitude(ctx),
+        "has_sign_flips": has_sign_flips(ctx),
+    }

--- a/tests/test_bridges.py
+++ b/tests/test_bridges.py
@@ -252,6 +252,88 @@ class BridgeMetabolicAccounting(unittest.TestCase):
             eb._mb = original_mb
 
 
+class BridgeMoneySignal(unittest.TestCase):
+    """audit/money_signal_bridge.py links Math-Econ to the money_signal
+    subsystem of metabolic-accounting. Like metabolic_bridge, the upstream
+    is NOT vendored, so the default-checkout behavior is _HAS_MONEY_SIGNAL=False.
+    """
+
+    def test_bridge_module_always_importable(self):
+        import money_signal_bridge as msb
+        self.assertIsInstance(msb._HAS_MONEY_SIGNAL, bool)
+        self.assertTrue(msb.UPSTREAM_PINNED_COMMIT)
+
+    def test_metrics_returns_none_when_absent(self):
+        import money_signal_bridge as msb
+        original = msb._HAS_MONEY_SIGNAL
+        try:
+            msb._HAS_MONEY_SIGNAL = False
+            self.assertIsNone(msb.money_signal_metrics())
+            self.assertIsNone(msb.default_context())
+        finally:
+            msb._HAS_MONEY_SIGNAL = original
+
+    def test_efficiency_audit_includes_money_signal_key(self):
+        """The audit result must always include a 'money_signal_metrics' key,
+        whether or not money_signal is importable."""
+        import efficiency_report_audit as era
+        from system_audit import SixSigmaAudit
+        result = era.audit_efficiency_report("precision_ag", SixSigmaAudit())
+        self.assertIn("money_signal_metrics", result)
+        metrics = result["money_signal_metrics"]
+        if metrics is None:
+            return  # bridge inactive — graceful degrade
+        for key in ("minsky", "magnitude", "has_sign_flips"):
+            self.assertIn(key, metrics)
+        self.assertIsInstance(metrics["has_sign_flips"], bool)
+
+    def test_equation_bridge_money_signal_returns_none_when_absent(self):
+        try:
+            import equation_bridge as eb
+        except ModuleNotFoundError as e:
+            self.skipTest(f"equation_bridge import requires numpy: {e}")
+        sm = eb.SystemMeasurement()
+        original = eb._HAS_MONEY_SIGNAL_BRIDGE
+        try:
+            eb._HAS_MONEY_SIGNAL_BRIDGE = False
+            self.assertIsNone(sm.check_money_signal())
+        finally:
+            eb._HAS_MONEY_SIGNAL_BRIDGE = original
+
+    def test_equation_bridge_money_signal_delegates(self):
+        """When the bridge is active, check_money_signal forwards ctx to
+        money_signal_bridge.money_signal_metrics."""
+        try:
+            import equation_bridge as eb
+        except ModuleNotFoundError as e:
+            self.skipTest(f"equation_bridge import requires numpy: {e}")
+        sm = eb.SystemMeasurement()
+
+        captured = {}
+
+        def fake_metrics(ctx=None):
+            captured["ctx"] = ctx
+            return {"minsky": 1.0, "magnitude": 0.5, "has_sign_flips": False}
+
+        original_has = eb._HAS_MONEY_SIGNAL_BRIDGE
+        original_msb = eb._msb
+        try:
+            eb._HAS_MONEY_SIGNAL_BRIDGE = True
+
+            class _StubBridge:
+                _HAS_MONEY_SIGNAL = True
+                money_signal_metrics = staticmethod(fake_metrics)
+
+            eb._msb = _StubBridge
+            sentinel = object()
+            result = sm.check_money_signal(ctx=sentinel)
+            self.assertEqual(result["minsky"], 1.0)
+            self.assertIs(captured["ctx"], sentinel)
+        finally:
+            eb._HAS_MONEY_SIGNAL_BRIDGE = original_has
+            eb._msb = original_msb
+
+
 class ImportDirectionInvariant(unittest.TestCase):
     """Vendored subtrees must not runtime-import Math-Econ.
 
@@ -273,6 +355,7 @@ class ImportDirectionInvariant(unittest.TestCase):
         "epistemic_cascade", "implementation_layer", "incentive_structure",
         "incentives_audit", "efficiency_report_audit",
         "ai_delusion_econ_checker", "metabolic_bridge",
+        "money_signal_bridge",
         # AI/
         "money_free_model", "semantic_decontamination", "temporal_energy",
         "equation_bridge",


### PR DESCRIPTION
## Summary

Fieldlinks Math-Econ into the `money_signal/` subsystem of [JinnZ2/metabolic-accounting](https://github.com/JinnZ2/metabolic-accounting) (CC0, stdlib-only), following the defensive-import pattern established by `audit/metabolic_bridge.py`. Pinned to upstream commit `09382a66` (same as the metabolic bridge).

- `audit/money_signal_bridge.py` exposes `default_context()` (neutral `DimensionalContext` baseline) and `money_signal_metrics(ctx=None)` returning `{"minsky", "magnitude", "has_sign_flips"}`.
- `audit/efficiency_report_audit.py` attaches `money_signal_metrics` alongside `physics_verdict` and `metabolic_verdict`.
- `AI/equation_bridge.py` adds `SystemMeasurement.check_money_signal(ctx=None)`.

## Why not fully collapse to `signal_quality`

Upstream's `money_signal/accounting_bridge.py` wraps the three primitives into a `signal_quality` float, but it does two things we don't want to depend on: (1) mutates `sys.path` at import time, (2) hard-imports `term_audit.integration.metabolic_accounting_adapter` — if `term_audit/` is absent the whole module fails to import. Exposing the three primitives raw sidesteps both, and gives callers more information than a single float. Downstream can still call `accounting_bridge.signal_quality` directly when appropriate.

## Why `investment_signal` is NOT included

I originally proposed a single bridge covering both signals. Upstream investigation found that at `09382a6`:
1. `investment_signal/__init__.py` does not exist, so `import investment_signal` fails.
2. `investment_signal/coupling.py` uses relative imports (`from ..money_signal.coupling import ...`) which require both packages to live under a shared parent package — the repo doesn't provide one.

Adding `investment_signal` would require either vendoring the upstream plus a shim `__init__.py`, or waiting for upstream to resolve packaging. Neither is in scope for this PR. Noted in `CLAUDE.md` for re-evaluation.

## Test plan

- [x] `python tests/test_bridges.py` — 22 tests, all pass (8 skip for missing numpy, same as before). 5 new tests cover: bridge always importable, `money_signal_metrics` + `default_context` return None when upstream absent, efficiency-audit integration key, equation_bridge fallback, equation_bridge delegation to bridge module.
- [x] `python audit/efficiency_report_audit.py` — full audit suite still runs end-to-end.
- [x] `money_signal_bridge` added to `ImportDirectionInvariant.ME_MODULE_NAMES`.

## Files changed

- `audit/money_signal_bridge.py` (new, 115 lines)
- `audit/efficiency_report_audit.py` (+7 lines)
- `AI/equation_bridge.py` (+22 lines)
- `tests/test_bridges.py` (+83 lines, 5 new tests)
- `CLAUDE.md` (+12 lines, documents the bridge and the `investment_signal` deferral)
