### PR TITLE
feat: investment_signal bridge + pin bump to 437e855

### DIFF
--- a/AI/equation_bridge.py
+++ b/AI/equation_bridge.py
@@ -64,6 +64,12 @@ try:
 except Exception:
     _HAS_MONEY_SIGNAL_BRIDGE = False
 
+try:
+    import investment_signal_bridge as _isb  # type: ignore
+    _HAS_INVESTMENT_SIGNAL_BRIDGE = True
+except Exception:
+    _HAS_INVESTMENT_SIGNAL_BRIDGE = False
+
 
 # ============================================================================
 # EQUATION RESULTS
@@ -233,6 +239,25 @@ class SystemMeasurement:
             regeneration_paid=regeneration_paid,
             stress=stress,
         )
+
+    def check_investment_signal(
+        self,
+        input_money: float,
+        expected_output_money: float,
+        ctx: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Run investment-signal assembly for a money-only investment and
+        return the key substrate / derivative / money metrics.
+
+        `ctx` is an `investment_signal.dimensions.InvestmentContext`; when
+        None, uses the bridge's neutral default (direct productive-capacity
+        investment at seasonal time-binding). Returns None when the
+        investment_signal_bridge module or its upstream package are not
+        available.
+        """
+        if not _HAS_INVESTMENT_SIGNAL_BRIDGE or not _isb._HAS_INVESTMENT_SIGNAL:
+            return None
+        return _isb.investment_signal_metrics(input_money, expected_output_money, ctx)
 
     def check_money_signal(
         self,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Mathematic-economics/
 │   ├── incentives_audit.py
 │   ├── metabolic_bridge.py             # Defensive bridge to JinnZ2/metabolic-accounting
 │   ├── money_signal_bridge.py          # Defensive bridge to money_signal/ subsystem
+│   ├── investment_signal_bridge.py     # Defensive bridge to investment_signal/ subsystem
 │   └── system_audit.py                 # Six Sigma-style audit on field_system outputs
 ├── calibration/                        # Falsifiable diagnostics + falsification test suite (stdlib only)
 │   ├── schema.py                       # Band / DimensionScore / CalibrationReport
@@ -178,10 +179,14 @@ A fifth bridge fieldlinks Math-Econ into the `money_signal/` subsystem of [JinnZ
 - **`audit/efficiency_report_audit.py`** — `audit_efficiency_report()` attaches `money_signal_metrics` to the result dict, alongside `physics_verdict` and `metabolic_verdict`.
 - **`AI/equation_bridge.py`** — `SystemMeasurement.check_money_signal(ctx=None)` forwards to the bridge.
 
-`investment_signal/` is deliberately NOT fieldlinked yet. At upstream commit `09382a6` the subsystem lacks an `__init__.py` and its modules use relative imports (`from ..money_signal import ...`) that require a shared parent package not present in the repo structure. Re-evaluate once upstream resolves that.
+### Investment-signal bridge
+A sixth bridge fieldlinks Math-Econ into the `investment_signal/` subsystem of metabolic-accounting. Same discovery logic as `metabolic_bridge.py`; sets `_HAS_INVESTMENT_SIGNAL = False` on failure. At the pinned commit upstream uses absolute imports (`from money_signal.coupling import ...`) and ships an `__init__.py`, so no shim is needed — flat imports work. Earlier upstream commits lacked these, which is why the bridge landed separately from money_signal.
+
+- **`audit/investment_signal_bridge.py`** — exposes `default_money_context()` / `default_investment_context()` (neutral `DimensionalContext` + `InvestmentContext` baselines) and `investment_signal_metrics(input_money, expected_output_money, ctx=None)` which builds two money-only `SubstrateVector`s (zeros across the other six substrates), calls `assemble_investment_signal`, and returns a plain dict with the 17 fields most useful for judgment (`time_binding_integrity`, `derivative_signal_reliability`, `money_minsky`, `is_financialized`, `substrate_invisible`, `dependency_broken`, `failure_count`, `failure_reasons`, etc.). For non-money substrate mixes, callers should invoke upstream's `assemble_investment_signal` directly.
+- **`AI/equation_bridge.py`** — `SystemMeasurement.check_investment_signal(input_money, expected_output_money, ctx=None)` forwards to the bridge.
 
 ### tests/test_bridges.py
-22 unittest tests verifying all five bridges end-to-end: import wiring, output shape, graceful fallback when PhysicsGuard / metabolic-accounting / money_signal is absent, and correct delegation through `SystemMeasurement` methods. Run with `python tests/test_bridges.py`. The 8 tests covering `equation_bridge` skip automatically in environments without numpy.
+27 unittest tests verifying all six bridges end-to-end: import wiring, output shape, graceful fallback when any upstream is absent, and correct delegation through `SystemMeasurement` methods. Run with `python tests/test_bridges.py`. The 10 tests covering `equation_bridge` skip automatically in environments without numpy.
 
 ### data/fetch_and_compute.py, data/sensitivity_analysis.py
 External data ingestion and Monte Carlo sensitivity analysis across weight and threshold ranges for the composite indices defined in `README.md`.

--- a/audit/investment_signal_bridge.py
+++ b/audit/investment_signal_bridge.py
@@ -1,0 +1,188 @@
+# investment_signal_bridge.py
+# Defensive bridge: Math-Econ -> JinnZ2/metabolic-accounting /investment_signal/ (CC0).
+#
+# Companion to audit/money_signal_bridge.py. Shares the same discovery
+# logic: probe a few conventional locations for a metabolic-accounting
+# checkout, set _HAS_INVESTMENT_SIGNAL = False if it can't be found.
+# Every helper returns None in the False case so consumers can wire the
+# call in unconditionally.
+#
+# To make the bridge active, place a checkout adjacent to this repo:
+#   <parent>/metabolic-accounting/    (default git clone name)
+# or vendor a snapshot inside this repo:
+#   <repo_root>/metabolic_accounting/
+#
+# History note: at earlier upstream commits investment_signal had no
+# __init__.py and used relative parent-package imports, so it was not
+# importable without a shim. At the pinned commit below, upstream uses
+# absolute imports (`from money_signal.coupling import ...`) and has a
+# normal __init__.py, so the bridge pattern is identical to the other
+# flat-import bridges (no shim needed).
+#
+# Pinned upstream version:
+#   repo:   https://github.com/JinnZ2/metabolic-accounting
+#   commit: 437e8551634ed33a613cdb41c41f28a51136eec7
+#   date:   2026-04-21
+# To upgrade, fetch the new HEAD, re-run `python tests/test_bridges.py`
+# with that checkout in place, and bump UPSTREAM_PINNED_COMMIT below.
+
+import os
+import sys
+from typing import Any, Dict, Optional
+
+UPSTREAM_PINNED_COMMIT = "437e8551634ed33a613cdb41c41f28a51136eec7"
+UPSTREAM_PINNED_DATE = "2026-04-21"
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_CANDIDATES = (
+    os.path.join(_REPO_ROOT, "metabolic_accounting"),
+    os.path.abspath(os.path.join(_REPO_ROOT, "..", "metabolic-accounting")),
+    os.path.abspath(os.path.join(_REPO_ROOT, "..", "metabolic_accounting")),
+)
+for _p in _CANDIDATES:
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)
+        break
+
+try:
+    from money_signal.dimensions import (  # type: ignore
+        AttributedValue,
+        CulturalScope,
+        DimensionalContext,
+        ObserverPosition,
+        StateRegime,
+        Substrate,
+        TemporalScope,
+    )
+    from investment_signal.dimensions import (  # type: ignore
+        DerivativeDistance,
+        InvestmentAttribution,
+        InvestmentContext,
+        InvestmentSubstrate,
+        TimeBinding,
+    )
+    from investment_signal.substrate_vectors import SubstrateVector  # type: ignore
+    from investment_signal.coupling import (  # type: ignore
+        assemble_investment_signal,
+        signal_failure_count,
+        signal_failure_reasons,
+    )
+    _HAS_INVESTMENT_SIGNAL = True
+except Exception:
+    _HAS_INVESTMENT_SIGNAL = False
+
+
+def default_money_context() -> Optional[Any]:
+    """Neutral `DimensionalContext` — modern digital-money institutional
+    economy in a healthy state. Matches `money_signal_bridge.default_context`
+    so both bridges see the same baseline.
+
+    Returns None when investment_signal is not importable.
+    """
+    if not _HAS_INVESTMENT_SIGNAL:
+        return None
+    return DimensionalContext(
+        temporal=TemporalScope.SEASONAL,
+        cultural=CulturalScope.INSTITUTIONAL,
+        attribution=AttributedValue.STATE_ENFORCED,
+        observer=ObserverPosition.TOKEN_HOLDER_DEEP,
+        substrate=Substrate.DIGITAL,
+        state=StateRegime.HEALTHY,
+    )
+
+
+def default_investment_context(money_ctx: Optional[Any] = None) -> Optional[Any]:
+    """Neutral `InvestmentContext` — direct (not derivative-layered)
+    productive-capacity investment at seasonal time-binding. When
+    `money_ctx` is None, uses `default_money_context()`.
+
+    Returns None when investment_signal is not importable.
+    """
+    if not _HAS_INVESTMENT_SIGNAL:
+        return None
+    if money_ctx is None:
+        money_ctx = default_money_context()
+    return InvestmentContext(
+        money_context=money_ctx,
+        attribution=InvestmentAttribution.PRODUCTIVE_CAPACITY,
+        derivative_distance=DerivativeDistance.DIRECT,
+        time_binding=TimeBinding.SEASONAL,
+    )
+
+
+def _money_only_vector(amount: float) -> Optional[Any]:
+    """Build a SubstrateVector with MONEY = amount and zeros in the other
+    six substrates. The length-7 assertion in upstream's
+    `validate_vector_storage` requires every substrate to appear."""
+    if not _HAS_INVESTMENT_SIGNAL:
+        return None
+    return SubstrateVector.from_dict({
+        **{s: 0.0 for s in InvestmentSubstrate},
+        InvestmentSubstrate.MONEY: float(amount),
+    })
+
+
+def investment_signal_metrics(
+    input_money: float,
+    expected_output_money: float,
+    ctx: Optional[Any] = None,
+) -> Optional[Dict[str, Any]]:
+    """Run investment-signal assembly for a money-only investment and
+    return the fields most useful for judgment.
+
+    Constructs two SubstrateVectors with MONEY set to the input/output
+    amounts (zeros elsewhere), assembles an InvestmentSignal via upstream,
+    and returns a plain dict:
+
+        time_binding_integrity            float   [0, 1]
+        derivative_signal_reliability     float   [0, 1]
+        substrate_visibility_at_distance  float   [0, 1]
+        cascade_coupling_at_distance      float   [0, 1]
+        reverse_causation_at_distance     float   [0, 1]
+        money_minsky                      float
+        money_magnitude                   float
+        money_sign_flips                  bool
+        money_near_collapse               bool
+        is_financialized                  bool
+        substrate_invisible               bool
+        liquidity_illusion                bool
+        infrastructure_depreciation_trap  bool
+        substrate_abstraction_breakdown_any bool
+        dependency_broken                 bool
+        failure_count                     int
+        failure_reasons                   list[str]
+
+    Returns None when investment_signal is not importable.
+
+    For investments with non-money substrate mixes (e.g. labor + time +
+    attention → productive capacity), callers should call upstream
+    `investment_signal.coupling.assemble_investment_signal` directly with
+    custom SubstrateVectors — this helper only covers the common
+    money-only case.
+    """
+    if not _HAS_INVESTMENT_SIGNAL:
+        return None
+    if ctx is None:
+        ctx = default_investment_context()
+    in_vec = _money_only_vector(input_money)
+    out_vec = _money_only_vector(expected_output_money)
+    sig = assemble_investment_signal(in_vec, out_vec, ctx)
+    return {
+        "time_binding_integrity": sig.time_binding_integrity,
+        "derivative_signal_reliability": sig.derivative_signal_reliability,
+        "substrate_visibility_at_distance": sig.substrate_visibility_at_distance,
+        "cascade_coupling_at_distance": sig.cascade_coupling_at_distance,
+        "reverse_causation_at_distance": sig.reverse_causation_at_distance,
+        "money_minsky": sig.money_minsky,
+        "money_magnitude": sig.money_magnitude,
+        "money_sign_flips": sig.money_sign_flips,
+        "money_near_collapse": sig.money_near_collapse,
+        "is_financialized": sig.is_financialized,
+        "substrate_invisible": sig.substrate_invisible,
+        "liquidity_illusion": sig.liquidity_illusion,
+        "infrastructure_depreciation_trap": sig.infrastructure_depreciation_trap,
+        "substrate_abstraction_breakdown_any": sig.substrate_abstraction_breakdown_any,
+        "dependency_broken": sig.dependency_broken,
+        "failure_count": signal_failure_count(sig),
+        "failure_reasons": list(signal_failure_reasons(sig)),
+    }

--- a/audit/metabolic_bridge.py
+++ b/audit/metabolic_bridge.py
@@ -18,7 +18,7 @@
 #
 # Pinned upstream version (the API surface this bridge was written against):
 #   repo:   https://github.com/JinnZ2/metabolic-accounting
-#   commit: 09382a66ce6ee63d84038c8ee35a1fbc28cda58d
+#   commit: 437e8551634ed33a613cdb41c41f28a51136eec7
 #   date:   2026-04-21
 # To upgrade, fetch the new HEAD, re-run `python tests/test_bridges.py`
 # with that checkout in place, and bump UPSTREAM_PINNED_COMMIT below.
@@ -27,7 +27,7 @@ import os
 import sys
 from typing import Any, Dict, Optional, Tuple
 
-UPSTREAM_PINNED_COMMIT = "09382a66ce6ee63d84038c8ee35a1fbc28cda58d"
+UPSTREAM_PINNED_COMMIT = "437e8551634ed33a613cdb41c41f28a51136eec7"
 UPSTREAM_PINNED_DATE = "2026-04-21"
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/audit/money_signal_bridge.py
+++ b/audit/money_signal_bridge.py
@@ -27,7 +27,7 @@
 #
 # Pinned upstream version:
 #   repo:   https://github.com/JinnZ2/metabolic-accounting
-#   commit: 09382a66ce6ee63d84038c8ee35a1fbc28cda58d
+#   commit: 437e8551634ed33a613cdb41c41f28a51136eec7
 #   date:   2026-04-21
 # To upgrade, fetch the new HEAD, re-run `python tests/test_bridges.py` with
 # that checkout in place, and bump UPSTREAM_PINNED_COMMIT below.
@@ -36,7 +36,7 @@ import os
 import sys
 from typing import Any, Dict, Optional
 
-UPSTREAM_PINNED_COMMIT = "09382a66ce6ee63d84038c8ee35a1fbc28cda58d"
+UPSTREAM_PINNED_COMMIT = "437e8551634ed33a613cdb41c41f28a51136eec7"
 UPSTREAM_PINNED_DATE = "2026-04-21"
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_bridges.py
+++ b/tests/test_bridges.py
@@ -334,6 +334,91 @@ class BridgeMoneySignal(unittest.TestCase):
             eb._msb = original_msb
 
 
+class BridgeInvestmentSignal(unittest.TestCase):
+    """audit/investment_signal_bridge.py links Math-Econ to the
+    investment_signal subsystem of metabolic-accounting. Upstream is NOT
+    vendored, so default-checkout behavior is _HAS_INVESTMENT_SIGNAL=False.
+    """
+
+    def test_bridge_module_always_importable(self):
+        import investment_signal_bridge as isb
+        self.assertIsInstance(isb._HAS_INVESTMENT_SIGNAL, bool)
+        self.assertTrue(isb.UPSTREAM_PINNED_COMMIT)
+
+    def test_returns_none_when_absent(self):
+        import investment_signal_bridge as isb
+        original = isb._HAS_INVESTMENT_SIGNAL
+        try:
+            isb._HAS_INVESTMENT_SIGNAL = False
+            self.assertIsNone(isb.default_money_context())
+            self.assertIsNone(isb.default_investment_context())
+            self.assertIsNone(isb.investment_signal_metrics(1000.0, 1100.0))
+        finally:
+            isb._HAS_INVESTMENT_SIGNAL = original
+
+    def test_metrics_shape_when_present(self):
+        """If the upstream package is present, investment_signal_metrics
+        must return the expected field set. Skips otherwise."""
+        import investment_signal_bridge as isb
+        if not isb._HAS_INVESTMENT_SIGNAL:
+            self.skipTest("investment_signal not importable on this checkout")
+        m = isb.investment_signal_metrics(1000.0, 1100.0)
+        self.assertIsNotNone(m)
+        for key in ("time_binding_integrity", "derivative_signal_reliability",
+                    "money_minsky", "is_financialized", "failure_count",
+                    "failure_reasons", "dependency_broken"):
+            self.assertIn(key, m)
+        self.assertIsInstance(m["is_financialized"], bool)
+        self.assertIsInstance(m["failure_count"], int)
+        self.assertIsInstance(m["failure_reasons"], list)
+
+    def test_equation_bridge_returns_none_when_absent(self):
+        try:
+            import equation_bridge as eb
+        except ModuleNotFoundError as e:
+            self.skipTest(f"equation_bridge import requires numpy: {e}")
+        sm = eb.SystemMeasurement()
+        original = eb._HAS_INVESTMENT_SIGNAL_BRIDGE
+        try:
+            eb._HAS_INVESTMENT_SIGNAL_BRIDGE = False
+            self.assertIsNone(sm.check_investment_signal(1000.0, 1100.0))
+        finally:
+            eb._HAS_INVESTMENT_SIGNAL_BRIDGE = original
+
+    def test_equation_bridge_delegates_amounts(self):
+        try:
+            import equation_bridge as eb
+        except ModuleNotFoundError as e:
+            self.skipTest(f"equation_bridge import requires numpy: {e}")
+        sm = eb.SystemMeasurement()
+        captured = {}
+
+        def fake_metrics(input_money, expected_output_money, ctx=None):
+            captured.update(input_money=input_money,
+                            expected_output_money=expected_output_money,
+                            ctx=ctx)
+            return {"money_minsky": 0.5, "is_financialized": False,
+                    "failure_count": 0, "failure_reasons": []}
+
+        original_has = eb._HAS_INVESTMENT_SIGNAL_BRIDGE
+        original_isb = eb._isb
+        try:
+            eb._HAS_INVESTMENT_SIGNAL_BRIDGE = True
+
+            class _Stub:
+                _HAS_INVESTMENT_SIGNAL = True
+                investment_signal_metrics = staticmethod(fake_metrics)
+
+            eb._isb = _Stub
+            result = sm.check_investment_signal(250.0, 300.0)
+            self.assertEqual(result["money_minsky"], 0.5)
+            self.assertEqual(captured["input_money"], 250.0)
+            self.assertEqual(captured["expected_output_money"], 300.0)
+        finally:
+            eb._HAS_INVESTMENT_SIGNAL_BRIDGE = original_has
+            eb._isb = original_isb
+
+
 class ImportDirectionInvariant(unittest.TestCase):
     """Vendored subtrees must not runtime-import Math-Econ.
 
@@ -355,7 +440,7 @@ class ImportDirectionInvariant(unittest.TestCase):
         "epistemic_cascade", "implementation_layer", "incentive_structure",
         "incentives_audit", "efficiency_report_audit",
         "ai_delusion_econ_checker", "metabolic_bridge",
-        "money_signal_bridge",
+        "money_signal_bridge", "investment_signal_bridge",
         # AI/
         "money_free_model", "semantic_decontamination", "temporal_energy",
         "equation_bridge",


### PR DESCRIPTION
## Summary

Fieldlinks Math-Econ into the `investment_signal/` subsystem of [JinnZ2/metabolic-accounting](https://github.com/JinnZ2/metabolic-accounting), and bumps the upstream pin to `437e8551` so the other bridges point at the same SHA.

### Upstream blocker resolved

Earlier when I looked at this subsystem, it was blocked on: no `investment_signal/__init__.py`, and submodules used relative imports (`from ..money_signal.coupling import ...`) that require a shared parent package not present in the repo. See the "Why `investment_signal` is NOT included" section of [PR #11](https://github.com/JinnZ2/Mathematic-economics/pull/11).

At the current upstream HEAD (`437e855`) both are fixed:
- `investment_signal/__init__.py` exists.
- Submodules use absolute imports (`from money_signal.coupling import ...`).

So the flat-imports discovery pattern used by the other bridges works identically here — no shim needed.

### What the bridge exposes

- `default_money_context()` / `default_investment_context()` — neutral baselines so callers don't need to construct 10 enums by hand.
- `investment_signal_metrics(input_money, expected_output_money, ctx=None)` — builds two money-only `SubstrateVector`s (zeros in the other six substrates), calls upstream's `assemble_investment_signal`, returns a plain dict with the 17 fields most useful for judgment: `time_binding_integrity`, `derivative_signal_reliability`, `substrate_visibility_at_distance`, `cascade_coupling_at_distance`, `reverse_causation_at_distance`, `money_minsky`, `money_magnitude`, `money_sign_flips`, `money_near_collapse`, `is_financialized`, `substrate_invisible`, `liquidity_illusion`, `infrastructure_depreciation_trap`, `substrate_abstraction_breakdown_any`, `dependency_broken`, `failure_count`, `failure_reasons`.

For non-money substrate mixes (e.g. labor + time + attention → productive capacity), callers should invoke upstream's `assemble_investment_signal` directly with custom `SubstrateVector`s. This helper only covers the common money-only case.

### Wiring

- `AI/equation_bridge.py` — new `SystemMeasurement.check_investment_signal(input_money, expected_output_money, ctx=None)`.
- **Not** wired into `audit/efficiency_report_audit.py` — the agricultural-report scenarios don't carry investment data; it's out of scope for that consumer.

### Pin bump

Also bumps `UPSTREAM_PINNED_COMMIT` in `metabolic_bridge.py` and `money_signal_bridge.py` from `09382a6` → `437e855`. The new bridge requires this SHA for the investment_signal packaging fix. The other bridges' dependency surfaces (`basin_states/`, `reserves/`, `accounting/`, `verdict/`, `money_signal.dimensions`, `money_signal.coupling`) are unchanged between those commits — verified by running the full test suite against the live HEAD checkout.

## Test plan

- [x] `python tests/test_bridges.py` — 27/27 pass (10 skip for missing numpy, +2 from the new investment_signal + equation_bridge delegation tests).
- [x] `test_metrics_shape_when_present` verified against a live upstream checkout — returns populated dict with all 17 fields. Skips gracefully when upstream is absent.
- [x] Graceful-fallback tests cover both the bridge module's own `_HAS_INVESTMENT_SIGNAL=False` path and `equation_bridge`'s `_HAS_INVESTMENT_SIGNAL_BRIDGE=False` path.
- [x] `investment_signal_bridge` added to `ImportDirectionInvariant.ME_MODULE_NAMES`.
- [x] `python audit/efficiency_report_audit.py` — full audit still runs end-to-end (no behavior change since investment_signal isn't wired there).

## Files changed

- `audit/investment_signal_bridge.py` (new, ~185 lines)
- `audit/metabolic_bridge.py` (+2 lines, pin bump only)
- `audit/money_signal_bridge.py` (+2 lines, pin bump only)
- `AI/equation_bridge.py` (+25 lines, new method + import)
- `tests/test_bridges.py` (+87 lines, 5 new tests + ME_MODULE_NAMES extension)
- `CLAUDE.md` (+8 lines, bridge section + file listing + tests section)

## Relationship to open PR #13

This PR branches from `main`, not PR #13. Both touch `metabolic_bridge.py` but in different sections (this PR: pin SHA; #13: new `basin_overrides` param + `basins_from_field_scenario`). Whichever merges first, the second will need a trivial rebase that git can auto-resolve.
