### PR TITLE
feat: compute_paradigm — ternary encoding + compute-paradigm registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Mathematic-economics/
 │   ├── accountability_protocol.py
 │   ├── ai_delusion_econ_checker.py     # Detect systemic assumptions in AI datasets
 │   ├── certification_protocol.py
+│   ├── compute_paradigm.py             # Ternary encoding + compute-paradigm registry
 │   ├── deflection_pattern_analyzer.py
 │   ├── efficiency_report_audit.py      # Audits industry "efficiency" report archetypes
 │   ├── epistemic_cascade.py
@@ -153,6 +154,9 @@ Substrate-agnostic extraction physics: the same energy-balance accounting applie
 
 ### schemas/field_system_contract.py
 `FieldSystemState` + `FieldSystemReport` + `YieldAnalysis` dataclasses mirroring the dict shape consumed and produced by `audit/field_system.py`. Consumers (`system_audit`, `efficiency_report_audit`) can adopt it incrementally for type-checked inputs. Versioned via `CONTRACT_VERSION`.
+
+### audit/compute_paradigm.py
+Alternative-computing scaffolding. Two tiers: (1) `encode_ternary(value)` encodes Math-Econ's naturally 3-valued enums — `ThresholdStatus`, `Coupling`, `Regime`, `ScopeStatus`, calibration `Band`, metabolic verdict strings — to balanced ternary `{-1, 0, +1}` (the fourth absorbing/unknown state in each returns `None`). `weighted_ternary_score(entries)` aggregates them with weights, skipping `None` and renormalizing. (2) `ComputeParadigmRegistry.instance()` is a bidirectional index of Math-Econ primitives to supported compute paradigms (`BINARY`, `TERNARY`, `STOCHASTIC`, `APPROXIMATE`, `OCTAHEDRAL`, `ANNEALING`, `RESERVOIR`, `QUANTUM`). Defaults declare what's computable today; `OCTAHEDRAL` / `ANNEALING` / `RESERVOIR` / `QUANTUM` are reserved for future fieldlinks to SOMS / Mandala-Computing / GtBCB. Tests: `python tests/test_compute_paradigm.py` (19 tests, stdlib-only).
 
 ### labor_thermodynamics/
 Markdown specifications for the five compounding labor-measurement failure modes (L1-L5). Sits next to the essay-style analysis files at the repo root; ported from thermodynamic-accountability-framework.

--- a/audit/compute_paradigm.py
+++ b/audit/compute_paradigm.py
@@ -1,0 +1,321 @@
+# compute_paradigm.py
+# Alternative-computing scaffolding for Math-Econ.
+#
+# Two pieces:
+#   1. Ternary encoding for Math-Econ's naturally 3-valued state
+#      (ThresholdStatus, Coupling, Regime, ScopeStatus, calibration Band,
+#      metabolic verdict band). Each encodes to balanced ternary {-1, 0, +1}.
+#      The fourth absorbing/unknown state in each enum (UNKNOWN, EXTINCT,
+#      BLACK, SCOPE_UNDECLARED) encodes to None.
+#
+#   2. A compute-paradigm registry so Math-Econ primitives can declare which
+#      alternative paradigms they natively support (ternary, stochastic,
+#      approximate, etc.). Mirrors the public-API shape of the registry
+#      pattern used in the surrounding JinnZ2 ecosystem (SOMS, GtBCB).
+#
+# Deliberately stdlib-only. No external substrate imports — this module
+# describes WHICH primitives could run on WHICH paradigms. Actual
+# substrate dispatch (e.g. running annealing on Mandala-Computing or
+# octahedral encoding via SOMS) is a separate fieldlink, not wired here.
+#
+# License: CC0 1.0 Universal
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ComputeParadigm(Enum):
+    """Computational paradigms a Math-Econ primitive can support.
+
+    BINARY is the default everything already supports (standard Python
+    floats / ints). The others describe alternative substrates where
+    the primitive has a defined, non-trivial encoding.
+    """
+    BINARY = "binary"              # standard floating-point / int
+    TERNARY = "ternary"            # balanced ternary {-1, 0, +1}
+    STOCHASTIC = "stochastic"      # Monte Carlo / probabilistic
+    APPROXIMATE = "approximate"    # scope-bounded, bounded-error
+    OCTAHEDRAL = "octahedral"      # 8-state cell (Mandala-Computing, SOMS)
+    ANNEALING = "annealing"        # simulated / quantum annealing
+    RESERVOIR = "reservoir"        # reservoir computing (dynamic systems)
+    QUANTUM = "quantum"            # superposition-based
+
+
+# ---------------------------------------------------------------------------
+# TIER 1: TERNARY ENCODING
+# ---------------------------------------------------------------------------
+# Convention: +1 means "most favorable / most certain / above threshold",
+# -1 means "least favorable / most extrapolated / below threshold",
+# 0 means "balanced / within range / moderate". The fourth absorbing or
+# unknown state per enum (UNKNOWN, EXTINCT, BLACK, SCOPE_UNDECLARED)
+# encodes to None — ternary arithmetic must skip or special-case these.
+# ---------------------------------------------------------------------------
+
+# Keyed by Enum name + member name so this module has no import-time
+# dependency on AI/equation_bridge.py, audit/study_scope_audit.py,
+# calibration/schema.py, or metabolic_bridge.py. Callers can pass
+# either the enum member or its .name string.
+_TERNARY_BY_NAME: Dict[str, Dict[str, Optional[int]]] = {
+    # AI/equation_bridge.py: ThresholdStatus
+    "ThresholdStatus": {
+        "ABOVE": +1,    # above threshold = more intense (OSDI direction)
+        "WITHIN": 0,
+        "BELOW": -1,
+        "UNKNOWN": None,
+    },
+    # audit/study_scope_audit.py: Coupling, Regime, ScopeStatus
+    "Coupling": {
+        "TIGHT": +1,    # scope-bound / high certainty
+        "MODERATE": 0,
+        "LOOSE": -1,    # extrapolated / high risk
+        "UNKNOWN": None,
+    },
+    "Regime": {
+        "STATIONARY": +1,
+        "DRIFTING": 0,
+        "NON_STATIONARY": -1,
+        "UNKNOWN": None,
+    },
+    "ScopeStatus": {
+        "IN_SCOPE": +1,
+        "EDGE_OF_SCOPE": 0,
+        "OUT_OF_SCOPE": -1,
+        "SCOPE_UNDECLARED": None,
+    },
+    # calibration/schema.py: Band
+    "Band": {
+        "GREEN": +1,
+        "YELLOW": 0,
+        "RED": -1,
+        "EXTINCT": None,   # absorbing: memorialized, not on the ternary axis
+    },
+    # metabolic_bridge.py: sustainable_yield_signal string values
+    "VerdictBand": {
+        "GREEN": +1,
+        "AMBER": 0,
+        "RED": -1,
+        "BLACK": None,     # absorbing: irreversibility, not "very RED"
+    },
+}
+
+
+def encode_ternary(value: Any) -> Optional[int]:
+    """Encode a Math-Econ 3+1-valued state to balanced ternary.
+
+    Accepts:
+      - An Enum member whose class name is registered in _TERNARY_BY_NAME
+        (ThresholdStatus, Coupling, Regime, ScopeStatus, Band).
+      - A raw string matching a VerdictBand value ("GREEN", "AMBER",
+        "RED", "BLACK") — this is how metabolic_bridge.py ships its
+        sustainable_yield_signal.
+
+    Returns {-1, 0, +1} for the three primary states, or None for the
+    fourth absorbing/unknown state. Raises ValueError on unrecognized
+    input.
+    """
+    if isinstance(value, Enum):
+        cls_name = type(value).__name__
+        table = _TERNARY_BY_NAME.get(cls_name)
+        if table is None:
+            raise ValueError(
+                f"no ternary encoding registered for enum {cls_name}; "
+                f"extend _TERNARY_BY_NAME or call register_ternary_mapping"
+            )
+        if value.name not in table:
+            raise ValueError(
+                f"enum member {cls_name}.{value.name} has no ternary mapping"
+            )
+        return table[value.name]
+
+    if isinstance(value, str):
+        # metabolic_bridge returns raw strings; try the VerdictBand table.
+        table = _TERNARY_BY_NAME["VerdictBand"]
+        if value in table:
+            return table[value]
+        raise ValueError(
+            f"string {value!r} is not a registered ternary state "
+            f"(expected one of {sorted(table.keys())})"
+        )
+
+    raise TypeError(
+        f"encode_ternary expects an Enum member or a VerdictBand string, "
+        f"got {type(value).__name__}"
+    )
+
+
+def register_ternary_mapping(enum_class_name: str,
+                             mapping: Dict[str, Optional[int]]) -> None:
+    """Register a ternary encoding for an additional enum class by name.
+
+    `mapping` is keyed by Enum member `.name` (not `.value`) and values
+    must be in {-1, 0, +1, None}. Callers wiring a new 3+1-valued enum
+    should call this from their own module, not import _TERNARY_BY_NAME
+    directly.
+    """
+    for member_name, ternary in mapping.items():
+        if ternary not in (-1, 0, 1, None):
+            raise ValueError(
+                f"{enum_class_name}.{member_name} -> {ternary}: "
+                f"ternary value must be -1, 0, +1, or None"
+            )
+    _TERNARY_BY_NAME[enum_class_name] = dict(mapping)
+
+
+def weighted_ternary_score(
+    entries: List[tuple],
+) -> Optional[float]:
+    """Aggregate ternary-encoded values with weights to a signed real score.
+
+    `entries` is a list of (ternary_or_None, weight) pairs. Entries with
+    None are skipped; their weight is removed from the normalizer so the
+    score stays in [-1, +1]. Returns None if every entry is None or the
+    total participating weight is zero.
+
+    Example (ternary OSDI across measured equations):
+
+        entries = [
+            (encode_ternary(sid_status),  0.30),
+            (encode_ternary(msi_status),  0.20),
+            (encode_ternary(isr_status),  0.20),
+            (encode_ternary(bsc_status),  0.15),
+            (encode_ternary(mm_status),   0.15),
+        ]
+        score = weighted_ternary_score(entries)
+        # +1 = all equations ABOVE threshold (max dependence)
+        #  0 = balanced / WITHIN
+        # -1 = all BELOW threshold
+    """
+    total_weight = 0.0
+    weighted_sum = 0.0
+    for ternary, weight in entries:
+        if ternary is None:
+            continue
+        total_weight += weight
+        weighted_sum += ternary * weight
+    if total_weight == 0.0:
+        return None
+    return weighted_sum / total_weight
+
+
+# ---------------------------------------------------------------------------
+# TIER 2: PRIMITIVE -> PARADIGM REGISTRY
+# ---------------------------------------------------------------------------
+# Declares which Math-Econ primitives natively support which alternative
+# paradigms beyond BINARY. Defaults installed in DEFAULT_REGISTRY below
+# describe what's available today; new primitives register via
+# `registry.register(name, [paradigms])`.
+# ---------------------------------------------------------------------------
+
+
+class ComputeParadigmRegistry:
+    """Bidirectional index of Math-Econ primitives to compute paradigms."""
+
+    _instance: Optional["ComputeParadigmRegistry"] = None
+
+    def __init__(self) -> None:
+        self._by_primitive: Dict[str, List[ComputeParadigm]] = {}
+
+    @classmethod
+    def instance(cls) -> "ComputeParadigmRegistry":
+        """Return the module-level singleton, building it lazily."""
+        if cls._instance is None:
+            cls._instance = cls()
+            _install_defaults(cls._instance)
+        return cls._instance
+
+    def register(self, primitive: str,
+                 paradigms: List[ComputeParadigm]) -> None:
+        """Declare that `primitive` supports `paradigms`. BINARY is always
+        implicit (everything supports standard float arithmetic) and is
+        added automatically if omitted."""
+        seen: List[ComputeParadigm] = []
+        if ComputeParadigm.BINARY not in paradigms:
+            seen.append(ComputeParadigm.BINARY)
+        for p in paradigms:
+            if p not in seen:
+                seen.append(p)
+        self._by_primitive[primitive] = seen
+
+    def paradigms_for(self, primitive: str) -> List[ComputeParadigm]:
+        """Paradigms the named primitive supports. Empty list if unknown."""
+        return list(self._by_primitive.get(primitive, ()))
+
+    def primitives_for_paradigm(
+        self, paradigm: ComputeParadigm
+    ) -> List[str]:
+        """Primitives that natively support the given paradigm."""
+        return sorted(
+            name for name, plist in self._by_primitive.items()
+            if paradigm in plist
+        )
+
+    def primitives(self) -> List[str]:
+        return sorted(self._by_primitive.keys())
+
+    def summary(self) -> str:
+        """Human-readable matrix: primitives x paradigms."""
+        paradigms = list(ComputeParadigm)
+        header = "primitive".ljust(32) + "".join(
+            p.value.ljust(13) for p in paradigms
+        )
+        rows = [header, "-" * len(header)]
+        for name in self.primitives():
+            supported = set(self._by_primitive[name])
+            row = name.ljust(32) + "".join(
+                ("x" if p in supported else ".").ljust(13) for p in paradigms
+            )
+            rows.append(row)
+        return "\n".join(rows)
+
+
+def _install_defaults(reg: ComputeParadigmRegistry) -> None:
+    """Seed the registry with Math-Econ's current primitives and the
+    paradigms they natively support.
+
+    Paradigms listed here are ones the repo can ACTUALLY compute in today:
+      - BINARY: always (implicit)
+      - TERNARY: primitives whose output is covered by encode_ternary
+      - STOCHASTIC: primitives already exercised by Monte Carlo
+        sensitivity analysis in data/sensitivity_analysis.py
+      - APPROXIMATE: primitives whose output is scope-bounded by
+        the calibration/ audit suite
+
+    Paradigms NOT listed (OCTAHEDRAL, ANNEALING, RESERVOIR, QUANTUM) are
+    left for future fieldlinks to SOMS / Mandala-Computing / GtBCB.
+    """
+    P = ComputeParadigm
+
+    # The 13 structural equations (AI/equation_bridge.py).
+    # Each produces an EquationResult with a ThresholdStatus → ternary.
+    for eq in ("VE_VL", "SID", "RI", "DI", "LWR", "MSI", "BSC", "MM",
+               "ISR", "UFR", "ER", "HHI", "SD"):
+        reg.register(eq, [P.BINARY, P.TERNARY, P.STOCHASTIC])
+
+    # Composite indices.
+    reg.register("OSDI", [P.BINARY, P.TERNARY, P.STOCHASTIC, P.APPROXIMATE])
+
+    # field_system yield / drift.
+    reg.register("field_system.effective_yield",
+                 [P.BINARY, P.STOCHASTIC])
+    reg.register("field_system.drift", [P.BINARY, P.STOCHASTIC])
+
+    # Audits with bounded verdicts.
+    reg.register("system_audit.SixSigmaAudit",
+                 [P.BINARY, P.STOCHASTIC, P.APPROXIMATE])
+    reg.register("calibration.pipeline",
+                 [P.BINARY, P.TERNARY, P.APPROXIMATE])
+
+    # Bridge verdicts (ternary via encode_ternary on the band strings).
+    reg.register("metabolic_bridge.metabolic_check",
+                 [P.BINARY, P.TERNARY])
+    reg.register("physics_guard.check",
+                 [P.BINARY, P.TERNARY, P.APPROXIMATE])
+    reg.register("money_signal_bridge.money_signal_metrics",
+                 [P.BINARY, P.STOCHASTIC])
+    reg.register("investment_signal_bridge.investment_signal_metrics",
+                 [P.BINARY, P.STOCHASTIC])
+
+    # Scope audits (study_scope_audit uses Coupling / Regime / ScopeStatus
+    # enums → ternary).
+    reg.register("study_scope_audit.StudyScopeAudit",
+                 [P.BINARY, P.TERNARY, P.APPROXIMATE])

--- a/tests/test_compute_paradigm.py
+++ b/tests/test_compute_paradigm.py
@@ -1,0 +1,187 @@
+"""Tests for audit/compute_paradigm.py — ternary encoding + registry.
+
+Run from the repo root:
+    python tests/test_compute_paradigm.py
+
+Stdlib-only. Covers the two tiers independently so the ternary layer
+doesn't require the registry and vice versa.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from enum import Enum
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for p in (REPO_ROOT, os.path.join(REPO_ROOT, "audit"),
+          os.path.join(REPO_ROOT, "calibration")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+class TernaryEncodingFromEnums(unittest.TestCase):
+
+    def test_threshold_status(self):
+        from compute_paradigm import encode_ternary
+
+        class ThresholdStatus(Enum):
+            BELOW = "below_threshold"
+            WITHIN = "within_range"
+            ABOVE = "above_threshold"
+            UNKNOWN = "unknown"
+
+        self.assertEqual(encode_ternary(ThresholdStatus.ABOVE), +1)
+        self.assertEqual(encode_ternary(ThresholdStatus.WITHIN), 0)
+        self.assertEqual(encode_ternary(ThresholdStatus.BELOW), -1)
+        self.assertIsNone(encode_ternary(ThresholdStatus.UNKNOWN))
+
+    def test_coupling_and_regime_and_scope(self):
+        from compute_paradigm import encode_ternary
+        from study_scope_audit import Coupling, Regime, ScopeStatus
+        self.assertEqual(encode_ternary(Coupling.TIGHT), +1)
+        self.assertEqual(encode_ternary(Coupling.MODERATE), 0)
+        self.assertEqual(encode_ternary(Coupling.LOOSE), -1)
+        self.assertIsNone(encode_ternary(Coupling.UNKNOWN))
+
+        self.assertEqual(encode_ternary(Regime.STATIONARY), +1)
+        self.assertEqual(encode_ternary(Regime.NON_STATIONARY), -1)
+        self.assertIsNone(encode_ternary(Regime.UNKNOWN))
+
+        self.assertEqual(encode_ternary(ScopeStatus.IN_SCOPE), +1)
+        self.assertEqual(encode_ternary(ScopeStatus.OUT_OF_SCOPE), -1)
+        self.assertIsNone(encode_ternary(ScopeStatus.SCOPE_UNDECLARED))
+
+    def test_calibration_band(self):
+        from compute_paradigm import encode_ternary
+        from schema import Band
+        self.assertEqual(encode_ternary(Band.GREEN), +1)
+        self.assertEqual(encode_ternary(Band.YELLOW), 0)
+        self.assertEqual(encode_ternary(Band.RED), -1)
+        self.assertIsNone(encode_ternary(Band.EXTINCT))
+
+    def test_verdict_band_strings(self):
+        """Metabolic bridge returns raw strings, not enums."""
+        from compute_paradigm import encode_ternary
+        self.assertEqual(encode_ternary("GREEN"), +1)
+        self.assertEqual(encode_ternary("AMBER"), 0)
+        self.assertEqual(encode_ternary("RED"), -1)
+        self.assertIsNone(encode_ternary("BLACK"))
+
+    def test_unknown_inputs_raise(self):
+        from compute_paradigm import encode_ternary
+
+        class Bogus(Enum):
+            FOO = "foo"
+
+        with self.assertRaises(ValueError):
+            encode_ternary(Bogus.FOO)
+        with self.assertRaises(ValueError):
+            encode_ternary("MAGENTA")
+        with self.assertRaises(TypeError):
+            encode_ternary(3.14)
+
+    def test_register_new_mapping(self):
+        from compute_paradigm import encode_ternary, register_ternary_mapping
+
+        class NewState(Enum):
+            HIGH = "h"
+            MID = "m"
+            LOW = "l"
+            OFF = "off"
+
+        register_ternary_mapping("NewState", {
+            "HIGH": +1, "MID": 0, "LOW": -1, "OFF": None,
+        })
+        self.assertEqual(encode_ternary(NewState.HIGH), +1)
+        self.assertIsNone(encode_ternary(NewState.OFF))
+
+    def test_register_rejects_invalid_values(self):
+        from compute_paradigm import register_ternary_mapping
+        with self.assertRaises(ValueError):
+            register_ternary_mapping("Bad", {"X": 2})
+
+
+class WeightedTernaryScore(unittest.TestCase):
+
+    def test_all_positive_yields_plus_one(self):
+        from compute_paradigm import weighted_ternary_score
+        self.assertAlmostEqual(
+            weighted_ternary_score([(+1, 0.5), (+1, 0.5)]), 1.0)
+
+    def test_all_negative_yields_minus_one(self):
+        from compute_paradigm import weighted_ternary_score
+        self.assertAlmostEqual(
+            weighted_ternary_score([(-1, 0.3), (-1, 0.7)]), -1.0)
+
+    def test_mixed_weighted(self):
+        from compute_paradigm import weighted_ternary_score
+        # +1 * 0.3 + 0 * 0.2 + -1 * 0.5 = -0.2
+        self.assertAlmostEqual(
+            weighted_ternary_score([(+1, 0.3), (0, 0.2), (-1, 0.5)]), -0.2)
+
+    def test_none_entries_skipped_and_weight_renormalized(self):
+        from compute_paradigm import weighted_ternary_score
+        # (+1, 0.5) + skipped (None, 0.5) => +1 after renormalization
+        self.assertAlmostEqual(
+            weighted_ternary_score([(+1, 0.5), (None, 0.5)]), 1.0)
+
+    def test_all_none_returns_none(self):
+        from compute_paradigm import weighted_ternary_score
+        self.assertIsNone(weighted_ternary_score([(None, 0.5), (None, 0.5)]))
+
+    def test_zero_total_weight_returns_none(self):
+        from compute_paradigm import weighted_ternary_score
+        self.assertIsNone(weighted_ternary_score([(+1, 0.0)]))
+
+
+class RegistryAPI(unittest.TestCase):
+
+    def test_singleton_is_stable(self):
+        from compute_paradigm import ComputeParadigmRegistry
+        a = ComputeParadigmRegistry.instance()
+        b = ComputeParadigmRegistry.instance()
+        self.assertIs(a, b)
+
+    def test_defaults_seed_13_equations(self):
+        from compute_paradigm import ComputeParadigm, ComputeParadigmRegistry
+        reg = ComputeParadigmRegistry.instance()
+        for eq in ("VE_VL", "SID", "MSI", "MM", "HHI", "SD"):
+            paradigms = reg.paradigms_for(eq)
+            self.assertIn(ComputeParadigm.BINARY, paradigms)
+            self.assertIn(ComputeParadigm.TERNARY, paradigms)
+            self.assertIn(ComputeParadigm.STOCHASTIC, paradigms)
+
+    def test_paradigms_for_unknown_is_empty(self):
+        from compute_paradigm import ComputeParadigmRegistry
+        self.assertEqual(
+            ComputeParadigmRegistry.instance().paradigms_for("NotAThing"),
+            [])
+
+    def test_primitives_for_paradigm_includes_13_equations(self):
+        from compute_paradigm import ComputeParadigm, ComputeParadigmRegistry
+        primitives = ComputeParadigmRegistry.instance().primitives_for_paradigm(
+            ComputeParadigm.TERNARY)
+        for eq in ("VE_VL", "SID", "HHI", "OSDI"):
+            self.assertIn(eq, primitives)
+
+    def test_register_adds_binary_implicitly(self):
+        from compute_paradigm import ComputeParadigm, ComputeParadigmRegistry
+        reg = ComputeParadigmRegistry()  # fresh, not singleton
+        reg.register("TestPrim", [ComputeParadigm.ANNEALING])
+        paradigms = reg.paradigms_for("TestPrim")
+        self.assertIn(ComputeParadigm.BINARY, paradigms)
+        self.assertIn(ComputeParadigm.ANNEALING, paradigms)
+
+    def test_summary_contains_all_primitives(self):
+        from compute_paradigm import ComputeParadigmRegistry
+        reg = ComputeParadigmRegistry.instance()
+        summary = reg.summary()
+        self.assertIn("VE_VL", summary)
+        self.assertIn("OSDI", summary)
+        self.assertIn("ternary", summary)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds alternative-computing scaffolding to Math-Econ, in two tiers inside a single module.

### Tier 1 — native ternary encoding

Math-Econ is already full of naturally 3-valued state, currently expressed as 4-member Python enums:

| source                         | enum              | 3 primary states                    | 4th absorbing / unknown |
|---                             |---                |---                                  |---                      |
| `AI/equation_bridge.py`        | `ThresholdStatus` | BELOW / WITHIN / ABOVE              | UNKNOWN                 |
| `audit/study_scope_audit.py`   | `Coupling`        | TIGHT / MODERATE / LOOSE            | UNKNOWN                 |
| `audit/study_scope_audit.py`   | `Regime`          | STATIONARY / DRIFTING / NON_STATIONARY | UNKNOWN              |
| `audit/study_scope_audit.py`   | `ScopeStatus`     | IN_SCOPE / EDGE_OF_SCOPE / OUT_OF_SCOPE | SCOPE_UNDECLARED   |
| `calibration/schema.py`        | `Band`            | GREEN / YELLOW / RED                | EXTINCT                 |
| `audit/metabolic_bridge.py`    | `VerdictBand` str | GREEN / AMBER / RED                 | BLACK                   |

`encode_ternary(value)` maps any of these to balanced ternary `{-1, 0, +1}`, or `None` for the absorbing/unknown state. Convention: `+1` = most favorable / most certain / above threshold. `weighted_ternary_score(entries)` aggregates `(ternary, weight)` pairs into a signed score in `[-1, +1]`, skipping `None` and renormalizing.

Composite indices like OSDI are now directly computable on a ternary substrate — call it with the per-equation `ThresholdStatus` values and weights, and you get `+1` (all ABOVE), `-1` (all BELOW), or a signed blend.

### Tier 2 — ComputeParadigmRegistry

Mirrors the `.instance()` / `paradigms_for` / `primitives_for_paradigm` / `summary` API shape used in the surrounding JinnZ2 ecosystem (SOMS, GtBCB).

```python
from compute_paradigm import ComputeParadigm, ComputeParadigmRegistry
reg = ComputeParadigmRegistry.instance()
reg.paradigms_for("OSDI")
# -> [BINARY, TERNARY, STOCHASTIC, APPROXIMATE]
reg.primitives_for_paradigm(ComputeParadigm.TERNARY)
# -> ['HHI', 'OSDI', 'SID', 'VE_VL', ..., 'metabolic_bridge.metabolic_check', ...]
print(reg.summary())
```

Seeded defaults declare paradigms the repo can compute in **today**:
- `BINARY` — always (implicit)
- `TERNARY` — primitives whose output is covered by `encode_ternary`
- `STOCHASTIC` — primitives already exercised by Monte Carlo in `data/sensitivity_analysis.py`
- `APPROXIMATE` — primitives whose output is scope-bounded by `calibration/`

`OCTAHEDRAL`, `ANNEALING`, `RESERVOIR`, `QUANTUM` are enumerated but left un-seeded — reserved for future fieldlinks to SOMS / Mandala-Computing / GtBCB. Not wired in this PR.

### Design choices

- **Stdlib-only.** No numpy, no external substrates. Safe to import before numpy-gated code paths.
- **No import-time dependency on the modules whose enums it encodes.** `encode_ternary` dispatches by `type(value).__name__`, so importing `compute_paradigm` does not trigger imports of `equation_bridge`, `study_scope_audit`, `calibration/schema`, or any bridge module. This keeps the encoder usable even in environments where those dependencies fail to import.
- **Extensible.** `register_ternary_mapping(class_name, mapping)` lets other modules add their own 3+1-valued enums without editing this file.

## Test plan

- [x] `python tests/test_compute_paradigm.py` — 19 new tests, all pass. Covers: ternary encoding for each enum source (including the string-based metabolic verdict path), `register_ternary_mapping` extensibility, invalid-input raises, weighted-score aggregator edge cases (all-positive / all-negative / mixed / None renormalization / zero-weight), and the registry API (singleton stability, default seeding, BINARY-implicit-on-register, summary contents).
- [x] `python tests/test_bridges.py` — 29/29 pass, no regression (10 skip for missing numpy as before).

## Files changed

- `audit/compute_paradigm.py` (new, ~320 lines — stdlib-only)
- `tests/test_compute_paradigm.py` (new, 19 tests)
- `CLAUDE.md` (+4 lines: file listing + module description section)

## Out of scope (future PRs)

- **Fieldlinking to SOMS / Mandala-Computing / GtBCB** for actual substrate dispatch of `OCTAHEDRAL` / `ANNEALING` / `RESERVOIR`. Requires real work — those upstreams have curated public APIs worth bridging but not from this registry module.
- **`.fieldlink.json` at repo root** declaring Math-Econ's ecosystem contract (what we export, what we consume). That's Tier 3 from the scoping discussion — pure metadata, needs separate review for what we're consenting to share.

## Note on unrelated state

`Study_scope_audit.py` (capital S, at repo root) currently exists on `main` as a duplicate of `audit/study_scope_audit.py`, introduced by commit `c996b15`. Not touched in this PR — belongs to a cleanup PR of its own so concerns stay separate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKC3SxNf4GF3R4doGtVPtH)_