### PR TITLE
feat(rfl_engine): RFL constraint-geometry tournament v3.2

### DIFF
--- a/rfl_engine/constraint_RFL_geometry.py
+++ b/rfl_engine/constraint_RFL_geometry.py
@@ -1,0 +1,304 @@
+# constraint_RFL_geometry.py  v3.2
+# repo: precursor-detection / RFL-engine   CC0   stdlib only   phone-buildable
+#
+# v3.2 adds, on top of v3.1's resonance-launder fix:
+#   - CascadeCoupling : signal propagates down a chain of transfer links,
+#                       terminating at a NAMED reservoir. no binary on/off.
+#   - no_silent_zero  : flags any coupling coeff / coords value pinned at 0
+#                       WITHOUT a stated forbidding reason. zero is a CLAIM.
+#   - kills() reports the sigma-margin so marginal (noise-band) verdicts
+#     can't masquerade as clean kills.
+#   - survival (physical permission) kept SEPARATE from adequacy (explains
+#     a real observable). adequacy is a branch tag, never a flat kill.
+#
+# rule burned in (the thing Kavik caught by eye):
+#   in a coupled system nothing sits at exactly 0. a "decoupled null" is
+#   almost always a mislabel of WHERE THE CHAIN TERMINATES. the honest null
+#   is the full chain ending at its real reservoir -- itself a nonzero coupling.
+
+from dataclasses import dataclass, field
+import itertools, math
+
+# ============================================================
+# 1. SPACE
+# ============================================================
+@dataclass
+class Space:
+    axes: list
+    weights: dict = field(default_factory=dict)
+    def weight(self, axis): return self.weights.get(axis, 1.0)
+
+# ============================================================
+# 2. HYPOTHESIS
+# ============================================================
+@dataclass
+class Hypothesis:
+    name: str
+    coords: dict
+    uncertainty: dict
+    note: str = ""
+    forbidden_zeros: dict = field(default_factory=dict)  # axis -> reason it's legitimately 0
+    def distance_to(self, other, space):
+        sq = sum(space.weight(a)*(self.coords.get(a,0.0)-other.coords.get(a,0.0))**2
+                 for a in space.axes)
+        return math.sqrt(sq)
+    def effective_radius(self, other, space):
+        return math.sqrt(sum((self.uncertainty.get(a,0.0)+other.uncertainty.get(a,0.0))**2
+                             for a in space.axes))
+
+# ============================================================
+# 3. CONSTRAINT  (kills() now returns sigma-margin)
+# ============================================================
+@dataclass
+class Constraint:
+    name: str
+    coeffs: dict
+    bound: float
+    op: str = ">"
+    desc: str = ""
+    layer: str = "permission"   # "permission" (physics) or "adequacy" (explains observable)
+    def violation(self, h):
+        val = sum(self.coeffs.get(k,0.0)*h.coords.get(k,0.0) for k in h.coords)
+        if self.op == ">":   return max(0.0, self.bound - val)
+        elif self.op == "<": return max(0.0, val - self.bound)
+        else:                return abs(val - self.bound)
+    def kills(self, h, k_sigma=2.0):
+        v = self.violation(h)
+        sigma = math.sqrt(sum((c*h.uncertainty.get(a,0.0))**2 for a,c in self.coeffs.items()))
+        margin = v - k_sigma*sigma           # >0 clean kill ; ~0 noise-band ; <0 survives
+        return v > k_sigma*sigma, v, sigma, margin
+
+# ============================================================
+# 4. COUPLING  (product/sum/threshold)
+# ============================================================
+@dataclass
+class Coupling:
+    name: str
+    input_axes: list
+    output_axis: str
+    coeff: float = 1.0
+    op: str = "product"
+    threshold: float = 0.5
+    def compute(self, p):
+        if self.op == "product":
+            v = self.coeff
+            for ax in self.input_axes: v *= p.get(ax,0.0)
+            return v
+        elif self.op == "sum":
+            return self.coeff*sum(p.get(ax,0.0) for ax in self.input_axes)
+        elif self.op == "threshold":
+            return self.coeff if all(p.get(ax,0.0)>self.threshold for ax in self.input_axes) else 0.0
+        return 0.0
+
+# ============================================================
+# 5. RESONANT COUPLING  (v3.1 fix: needs excitation power at eigenfreq)
+# ============================================================
+@dataclass
+class ResonantCoupling:
+    name: str
+    excitation_axis: str
+    frequency_axis: str
+    phase_axis: str
+    q_axis: str
+    output_axis: str
+    @property
+    def input_axes(self):
+        return [self.excitation_axis, self.frequency_axis, self.phase_axis, self.q_axis]
+    def compute(self, p):
+        E, f = p.get(self.excitation_axis,0.0), p.get(self.frequency_axis,0.0)
+        ph, Q = p.get(self.phase_axis,0.0), p.get(self.q_axis,0.0)
+        if Q<=0 or E<=0: return 0.0           # no driver / no resonator -> no amplitude
+        lorentz = 1.0/(1.0 + ((f-1.0)/(1.0/Q))**2)
+        return E * Q * lorentz * math.cos(ph*math.pi/2)
+
+# ============================================================
+# 6. CASCADE COUPLING  (v3.2: chain of transfer links -> named reservoir)
+#    signal_in propagates through links; each link multiplies by its transfer.
+#    output is what SURVIVES to the terminus. NO binary on/off.
+#    use this instead of zeroing a coupling: name the reservoir where it ends.
+# ============================================================
+@dataclass
+class CascadeCoupling:
+    name: str
+    input_axis: str                 # source signal axis
+    links: list                     # [(label, transfer_coeff, note), ...]
+    output_axis: str                # terminus reservoir axis
+    terminus: str = ""              # human name of where the chain ends
+    @property
+    def input_axes(self): return [self.input_axis]
+    def compute(self, p):
+        sig = p.get(self.input_axis, 0.0)
+        for _, k, _ in self.links:
+            sig *= k
+        return sig
+    def trace(self, p):
+        sig = p.get(self.input_axis, 0.0); out = [("source", sig)]
+        for label, k, _ in self.links:
+            sig *= k; out.append((label, sig))
+        return out
+
+# ============================================================
+# 7. NO SILENT ZERO  (v3.2: zero is a claim, not a default)
+# ============================================================
+def no_silent_zero(h, coupling_axes):
+    """Flag any coupling axis pinned at exactly 0 without a stated reason.
+       coupling_axes: axes that represent physical couplings (never structurally 0
+       unless forbidden)."""
+    flags = []
+    for ax in coupling_axes:
+        if abs(h.coords.get(ax, 0.0)) < 1e-12:
+            reason = h.forbidden_zeros.get(ax)
+            if not reason:
+                flags.append(ax)
+    return flags
+
+# ============================================================
+# 8. COMPOUND HYPOTHESIS
+# ============================================================
+@dataclass
+class CompoundHypothesis:
+    name: str
+    bases: list
+    couplings: list
+    note: str = ""
+    forbidden_zeros: dict = field(default_factory=dict)
+    def emerge(self):
+        coords, unc = {}, {}
+        for h in self.bases:
+            coords.update(h.coords); unc.update(h.uncertainty)
+        for coup in self.couplings:
+            coords[coup.output_axis] = coup.compute(coords)
+            unc[coup.output_axis] = math.sqrt(sum(unc.get(a,0.1)**2 for a in coup.input_axes))
+        return Hypothesis(self.name, coords, unc, self.note, self.forbidden_zeros)
+
+# ============================================================
+# 9. TOURNAMENT  (permission/adequacy split, sigma-margin, zero-flags)
+# ============================================================
+@dataclass
+class Tournament:
+    space: Space
+    hypotheses: list
+    constraints: list
+    distinct_threshold: float = 1.0
+    coupling_axes: list = field(default_factory=list)   # axes subject to no_silent_zero
+    def run(self, k_sigma=2.0, branch="permission_only"):
+        # branch: "permission_only" -> only permission-layer constraints kill
+        #         "with_adequacy"   -> adequacy-layer constraints also kill
+        resolved = [h.emerge() if isinstance(h, CompoundHypothesis) else h for h in self.hypotheses]
+        active = [c for c in self.constraints
+                  if c.layer=="permission" or branch=="with_adequacy"]
+        alive, killed = [], []
+        for h in resolved:
+            violations, dead = [], False
+            for c in active:
+                k, v, sigma, margin = c.kills(h, k_sigma)
+                if k:
+                    dead = True
+                    violations.append({"constraint":c.name,"layer":c.layer,
+                        "violation":round(v,4),"sigma_normal":round(sigma,4),
+                        "margin":round(margin,4),
+                        "verdict":"CLEAN" if margin>sigma else "NOISE-BAND"})
+            zflags = no_silent_zero(h, self.coupling_axes)
+            if dead: killed.append((h, violations, zflags))
+            else:    alive.append((h, zflags))
+        pairs = list(itertools.combinations([h for h,_ in alive], 2))
+        conflicts, distinct = [], []
+        for a,b in pairs:
+            d=a.distance_to(b,self.space); r=a.effective_radius(b,self.space)
+            (conflicts if d<r*self.distinct_threshold else distinct).append(
+                (a.name,b.name,round(d,3),round(r,3)))
+        names=[h.name for h,_ in alive]; parent={n:n for n in names}
+        def find(x):
+            while parent[x]!=x: parent[x]=parent[parent[x]]; x=parent[x]
+            return x
+        def union(x,y):
+            rx,ry=find(x),find(y)
+            if rx!=ry: parent[ry]=rx
+        for a,b in pairs:
+            d=a.distance_to(b,self.space); r=a.effective_radius(b,self.space)
+            if d<r*self.distinct_threshold: union(a.name,b.name)
+        clusters={}
+        for n in names: clusters.setdefault(find(n),[]).append(n)
+        return {
+            "branch":branch,
+            "alive":[{"name":n,"silent_zero_flags":z} for (h,z) in alive for n in [h.name]],
+            "killed":[{"name":h.name,"violations":vl,"silent_zero_flags":z}
+                      for h,vl,z in killed],
+            "conflicts":conflicts,"distinct_pairs":distinct,"clusters":clusters,
+            "score":{"viability":len(alive),"diversity":len(distinct),
+                     "connected_regions":len(clusters),
+                     "collapse":(len(clusters)<=1 and len(alive)>1)}
+        }
+
+# ============================================================
+# 10. DEMO  -- the strat<->mantle problem, done honestly
+# ============================================================
+def demo():
+    axes = ["strat_CO2_cooling","atmos_opacity","mech_coupling","electric_power_mantle",
+            "rotation_signal","mantle_stress_anomaly","mantle_convective_anomaly"]
+    space = Space(axes=axes)
+    coupling_axes = ["mech_coupling","rotation_signal",
+                     "mantle_stress_anomaly","mantle_convective_anomaly"]
+
+    # the cascade: rad cooling -> ... -> rotation reservoir. NONZERO, measured.
+    to_rotation = CascadeCoupling("rad_to_rotation","strat_CO2_cooling",
+        links=[("convective_adjust",0.9,"rad eq unstable -> convection mandatory"),
+               ("meridional_gradient",0.7,"strat cooling sharpens gradient"),
+               ("vortex_jet",0.8,"thermal wind; vortex strengthens (observed)"),
+               ("AAM",0.6,"zonal wind change = AAM change"),
+               ("LOD",0.5,"IERS-measured seasonal LOD")],
+        output_axis="rotation_signal", terminus="Earth rotation / LOD")
+    # terminal links off rotation
+    to_stress = Coupling("rot_to_stress",["rotation_signal"],"mantle_stress_anomaly",
+                         coeff=0.05, op="sum")     # small, NONZERO (rotational deformation)
+    to_conv   = Coupling("rot_to_convection",["rotation_signal"],"mantle_convective_anomaly",
+                         coeff=1e-9, op="sum")      # ~0 (buoyancy/Myr decoupled)
+
+    chain = CompoundHypothesis("Chain_terminating_at_rotation",
+        [Hypothesis("b",{"strat_CO2_cooling":0.9,"atmos_opacity":0.8,
+                         "mech_coupling":0.1,"electric_power_mantle":0.0},
+                    {a:0.05 for a in axes})],
+        [to_rotation, to_stress, to_conv],
+        "honest null: full chain, terminates at rotation, leaks small stress signal")
+
+    permission = [
+        Constraint("strat_cooling_observed",{"strat_CO2_cooling":1.0},0.3,">"),
+        Constraint("angular_momentum_limit",{"mech_coupling":1.0},0.2,"<"),
+        Constraint("electric_power_impossible",{"electric_power_mantle":1.0},0.0001,"<"),
+        Constraint("convective_decoupled",{"mantle_convective_anomaly":1.0},0.15,"<",
+                   "decadal torque cannot drive buoyancy convection"),
+    ]
+    adequacy = [
+        Constraint("explains_velocity_anomaly",{"mantle_stress_anomaly":1.0},0.001,">",
+                   layer="adequacy",
+                   desc="if a real seismic-velocity anomaly exists, stress link must reach it"),
+    ]
+
+    t = Tournament(space,[chain],permission+adequacy,coupling_axes=coupling_axes)
+
+    print("=== RFL v3.2 -- strat<->mantle, honest cascade ===\n")
+    em = chain.emerge()
+    print("CASCADE TRACE (no link is zero):")
+    for label,val in to_rotation.trace(em.coords):
+        print(f"   {label:22s} signal={val:.4f}")
+    print(f"   --> terminus: {to_rotation.terminus}\n")
+    print(f"   rotation -> mantle STRESS      = {em.coords['mantle_stress_anomaly']:.4e}  (small, real)")
+    print(f"   rotation -> mantle CONVECTION  = {em.coords['mantle_convective_anomaly']:.4e}  (~zero)\n")
+
+    print("BRANCH A (anomaly not field-real): permission only")
+    rA = t.run(branch="permission_only")
+    print("   alive:", [a["name"] for a in rA["alive"]])
+    print("   -> chain permitted. it's the baseline coupling that always exists.\n")
+
+    print("BRANCH B (seismic-velocity anomaly IS real): + adequacy")
+    rB = t.run(branch="with_adequacy")
+    print("   alive:", [a["name"] for a in rB["alive"]])
+    print("   -> stress link reaches it. no new physics. 'heat anomaly' was a mislabel.\n")
+
+    print("no_silent_zero check on coupling axes:", coupling_axes)
+    for a in rA["alive"]:
+        flags = a["silent_zero_flags"]
+        print(f"   {a['name']}: {'OK' if not flags else 'FLAGGED zeros w/o reason: '+str(flags)}")
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
New top-level directory rfl_engine/ for the constraint-falsification hypothesis-tournament engine. First module: constraint_RFL_geometry.py at v3.2 (carries v3.1's resonance-launder fix and adds three v3.2 features that the strat<->mantle test case forced into existence).

Core abstractions (stdlib-only, mobile-runnable)

  Space          Weighted axis list. distance + effective_radius are
                 measured in this space.
  Hypothesis     coords + uncertainty per axis; carries a
                 forbidden_zeros dict whose keys are axes where 0 is
                 a legitimate claim and whose values are the stated
                 reason (e.g. "buoyancy/Myr decoupled").
  Constraint     coeffs + bound + op (>, <, =), tagged with a layer
                 ("permission" = physics; "adequacy" = explains a
                 specific observable). kills(h, k_sigma) returns
                 (verdict, violation, sigma_normal, margin) so a
                 marginal kill near sigma can be tagged NOISE-BAND
                 rather than CLEAN.
  Coupling       product / sum / threshold over input axes.
  ResonantCoupling (v3.1) requires excitation power at eigenfreq.
                 If Q<=0 or E<=0 -> 0 (no driver, no resonator).
                 Closes the v3.0 launder where any axis could
                 "resonate" itself into a kill.
  CascadeCoupling (v3.2) signal propagates down a chain of transfer
                 links, terminating at a NAMED reservoir. compute()
                 multiplies through; trace() returns the signal at
                 each link for the report. Replaces "this coupling
                 is zero" with "this coupling terminates here, at
                 this real reservoir, with this transfer chain."
  CompoundHypothesis  bases + couplings -> emerged Hypothesis with
                 propagated coords and quadrature-combined uncertainty.
  Tournament     runs constraints in two branches: permission_only
                 (only physics kills) and with_adequacy (adequacy
                 constraints also kill -- triggered only when the
                 observable they describe is actually field-real).
                 Union-find clusters alive hypotheses by indistinguish-
                 ability. collapse flag fires when >1 alive hypothesis
                 lives in <=1 cluster (your distinct-pairs count went
                 to zero -- the diversity floor).

v3.2 additions in detail

1) CascadeCoupling
   The rule the demo encodes verbatim from the v3.2 header:

     "in a coupled system nothing sits at exactly 0. a 'decoupled
      null' is almost always a mislabel of WHERE THE CHAIN TERMINATES.
      the honest null is the full chain ending at its real reservoir
      -- itself a nonzero coupling."

   The demo's rad_to_rotation cascade chains strat_CO2_cooling through
   convective_adjust(0.9) -> meridional_gradient(0.7) -> vortex_jet(0.8)
   -> AAM(0.6) -> LOD(0.5), terminating at "Earth rotation / LOD"
   with signal 0.136 at the terminus. Then two terminal Couplings:

     rot_to_stress       coeff 0.05    -> mantle_stress = 6.8e-3
     rot_to_convection   coeff 1e-9    -> mantle_conv   = 1.4e-10

   The second is small-but-stated, not silently 0. The reason
   ("decadal torque cannot drive buoyancy convection") is what
   licenses the small magnitude. Same pattern is then exposed for
   peer review.

2) no_silent_zero(h, coupling_axes)
   Pure function. Walks the named coupling_axes and flags any whose
   coords value is < 1e-12 in absolute terms WITHOUT a matching
   entry in forbidden_zeros. Returns the axis names. The Tournament
   attaches the flag list to each alive/killed entry so a hypothesis
   that survived by silently zeroing a coupling axis cannot pass
   review unchallenged.

3) kills() sigma-margin verdict
   v3.1 returned (killed: bool). v3.2 returns the violation, the
   propagated sigma_normal across the constraint's coefficients,
   and the margin = violation - k_sigma*sigma. A constraint kill
   carries one of two verdicts:

     CLEAN       margin > sigma         (well outside the noise band)
     NOISE-BAND  0 < margin <= sigma    (kill is real but barely)

   Marginal kills no longer masquerade as decisive ones.

4) Permission / adequacy layer split
   permission = physical possibility (do conservation laws / known
     bounds permit this hypothesis at all?)
   adequacy   = explanatory power (does this hypothesis reach a
     specific observed magnitude?)

   The demo's adequacy constraint
     explains_velocity_anomaly: stress > 0.001
   fires only when the operator declares the velocity anomaly is
   field-real. In branch A (anomaly not observed) the chain is
   permitted but not asked to explain anything. In branch B
   (anomaly observed) it is asked, and the stress link's 6.8e-3
   reaches the 0.001 bound -- the chain explains the observable
   without any new physics.

   This is the same shape as the ozone v2 inversion: when the
   standard chain CAN reach the observation, "new physics" is the
   mislabel.

Demo verdict (smoke output reproduced verbatim in the smoke harness)

  Cascade trace, no link is zero:
    source                 0.9000
    convective_adjust      0.8100
    meridional_gradient    0.5670
    vortex_jet             0.4536
    AAM                    0.2722
    LOD                    0.1361
    --> terminus: Earth rotation / LOD

    rotation -> mantle stress      = 6.8e-3   (small, real)
    rotation -> mantle convection  = 1.4e-10  (~zero, stated reason)

  branch A (permission only):     chain alive
  branch B (with adequacy):       chain alive
  no_silent_zero:                 OK on Chain_terminating_at_rotation

The point: a fluent "the strat is decoupled from the mantle" claim is structurally what zeroing a coupling without naming the terminus looks like. The cascade pattern makes the terminus mandatory; the silent-zero pass makes any remaining zero a documented claim, not a default. Verdicts that come out of this tournament are honest about what was killed, what was permitted, what the noise band is, and what coupling magnitudes were too small to matter but had to be named to be allowed.

Methodology rule preserved from the other JinnZ2/* repos:
  if field data refutes the chain, update the chain. never retune
  the model to look clean.

https://claude.ai/code/session_01TFbee4AmxyFKUhDf6d3ecB